### PR TITLE
Feature/rental station

### DIFF
--- a/server/src/main/java/site/bannabe/server/domain/rentals/controller/RentalStationController.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/controller/RentalStationController.java
@@ -1,14 +1,17 @@
 package site.bannabe.server.domain.rentals.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import site.bannabe.server.domain.rentals.controller.response.RentalItemDetailResponse;
 import site.bannabe.server.domain.rentals.controller.response.RentalStationDetailResponse;
 import site.bannabe.server.domain.rentals.controller.response.RentalStationSimpleResponse;
 import site.bannabe.server.domain.rentals.service.RentalStationService;
+import site.bannabe.server.global.security.auth.PrincipalDetails;
 
 @RestController
 @RequestMapping("/v1/stations")
@@ -31,6 +34,13 @@ public class RentalStationController {
   public RentalItemDetailResponse getRentalItemDetail(@PathVariable("stationId") Long stationId,
       @PathVariable("itemTypeId") Long itemTypeId) {
     return rentalStationService.getRentalItemDetail(stationId, itemTypeId);
+  }
+
+  @PostMapping("/{stationId}/bookmark")
+  public void bookmarkRentalStation(@PathVariable("stationId") Long stationId,
+      @AuthenticationPrincipal PrincipalDetails principalDetails) {
+    String email = principalDetails.getUsername();
+    rentalStationService.bookmarkRentalStation(stationId, email);
   }
 
 }

--- a/server/src/main/java/site/bannabe/server/domain/rentals/controller/RentalStationController.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/controller/RentalStationController.java
@@ -1,0 +1,36 @@
+package site.bannabe.server.domain.rentals.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import site.bannabe.server.domain.rentals.controller.response.RentalItemDetailResponse;
+import site.bannabe.server.domain.rentals.controller.response.RentalStationDetailResponse;
+import site.bannabe.server.domain.rentals.controller.response.RentalStationSimpleResponse;
+import site.bannabe.server.domain.rentals.service.RentalStationService;
+
+@RestController
+@RequestMapping("/v1/stations")
+@RequiredArgsConstructor
+public class RentalStationController {
+
+  private final RentalStationService rentalStationService;
+
+  @GetMapping
+  public RentalStationSimpleResponse getAllRentalStation() {
+    return rentalStationService.getAllRentalStations();
+  }
+
+  @GetMapping("/{stationId}")
+  public RentalStationDetailResponse getRentalStationDetail(@PathVariable("stationId") Long stationId) {
+    return rentalStationService.getRentalStationDetail(stationId);
+  }
+
+  @GetMapping("/{stationId}/items/{itemTypeId}")
+  public RentalItemDetailResponse getRentalItemDetail(@PathVariable("stationId") Long stationId,
+      @PathVariable("itemTypeId") Long itemTypeId) {
+    return rentalStationService.getRentalItemDetail(stationId, itemTypeId);
+  }
+
+}

--- a/server/src/main/java/site/bannabe/server/domain/rentals/controller/response/RentalItemDetailResponse.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/controller/response/RentalItemDetailResponse.java
@@ -1,0 +1,12 @@
+package site.bannabe.server.domain.rentals.controller.response;
+
+public record RentalItemDetailResponse(
+    String name,
+    String image,
+    String category,
+    String description,
+    Integer price,
+    Integer stock
+) {
+
+}

--- a/server/src/main/java/site/bannabe/server/domain/rentals/controller/response/RentalStationDetailResponse.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/controller/response/RentalStationDetailResponse.java
@@ -1,0 +1,19 @@
+package site.bannabe.server.domain.rentals.controller.response;
+
+import java.util.List;
+
+public record RentalStationDetailResponse(
+    List<RentalItemResponse> rentalItems
+) {
+
+  public record RentalItemResponse(
+      Long itemTypeId,
+      String name,
+      String image,
+      String category,
+      Integer stock
+  ) {
+
+  }
+
+}

--- a/server/src/main/java/site/bannabe/server/domain/rentals/controller/response/RentalStationSimpleResponse.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/controller/response/RentalStationSimpleResponse.java
@@ -1,0 +1,42 @@
+package site.bannabe.server.domain.rentals.controller.response;
+
+import java.math.BigDecimal;
+import java.util.List;
+import site.bannabe.server.domain.rentals.entity.RentalStations;
+
+public record RentalStationSimpleResponse(
+    List<StationResponse> stations
+) {
+
+  public static RentalStationSimpleResponse create(List<RentalStations> rentalStations) {
+    List<StationResponse> stationResponses = rentalStations.stream().map(StationResponse::create).toList();
+    return new RentalStationSimpleResponse(stationResponses);
+  }
+
+  public record StationResponse(
+      String name,
+      String address,
+      BigDecimal latitude,
+      BigDecimal longitude,
+      String status,
+      String businessTime,
+      String grade,
+      Long stationId
+  ) {
+
+    public static StationResponse create(RentalStations rentalStations) {
+      return new StationResponse(
+          rentalStations.getName(),
+          rentalStations.getAddress(),
+          rentalStations.getLatitude(),
+          rentalStations.getLongitude(),
+          rentalStations.getStatus().name(),
+          rentalStations.getOpenTime() + " ~ " + rentalStations.getCloseTime(),
+          rentalStations.getGrade().name(),
+          rentalStations.getId()
+      );
+    }
+
+  }
+
+}

--- a/server/src/main/java/site/bannabe/server/domain/rentals/repository/RentalHistoryRepository.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/repository/RentalHistoryRepository.java
@@ -2,6 +2,7 @@ package site.bannabe.server.domain.rentals.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import site.bannabe.server.domain.rentals.entity.RentalHistory;
+import site.bannabe.server.domain.rentals.repository.querydsl.CustomRentalHistoryRepository;
 
 public interface RentalHistoryRepository extends JpaRepository<RentalHistory, Long>, CustomRentalHistoryRepository {
 

--- a/server/src/main/java/site/bannabe/server/domain/rentals/repository/RentalItemRepository.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/repository/RentalItemRepository.java
@@ -1,0 +1,9 @@
+package site.bannabe.server.domain.rentals.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.bannabe.server.domain.rentals.entity.RentalItemTypes;
+import site.bannabe.server.domain.rentals.repository.querydsl.CustomRentalItemRepository;
+
+public interface RentalItemRepository extends JpaRepository<RentalItemTypes, Long>, CustomRentalItemRepository {
+
+}

--- a/server/src/main/java/site/bannabe/server/domain/rentals/repository/RentalStationRepository.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/repository/RentalStationRepository.java
@@ -1,0 +1,9 @@
+package site.bannabe.server.domain.rentals.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.bannabe.server.domain.rentals.entity.RentalStations;
+import site.bannabe.server.domain.rentals.repository.querydsl.CustomRentalStationRepository;
+
+public interface RentalStationRepository extends JpaRepository<RentalStations, Long>, CustomRentalStationRepository {
+
+}

--- a/server/src/main/java/site/bannabe/server/domain/rentals/repository/querydsl/CustomRentalHistoryRepository.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/repository/querydsl/CustomRentalHistoryRepository.java
@@ -1,4 +1,4 @@
-package site.bannabe.server.domain.rentals.repository;
+package site.bannabe.server.domain.rentals.repository.querydsl;
 
 import java.util.List;
 import org.springframework.data.domain.Page;

--- a/server/src/main/java/site/bannabe/server/domain/rentals/repository/querydsl/CustomRentalHistoryRepositoryImpl.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/repository/querydsl/CustomRentalHistoryRepositoryImpl.java
@@ -1,4 +1,10 @@
-package site.bannabe.server.domain.rentals.repository;
+package site.bannabe.server.domain.rentals.repository.querydsl;
+
+import static site.bannabe.server.domain.rentals.entity.QRentalHistory.rentalHistory;
+import static site.bannabe.server.domain.rentals.entity.QRentalItemTypes.rentalItemTypes;
+import static site.bannabe.server.domain.rentals.entity.QRentalItems.rentalItems;
+import static site.bannabe.server.domain.rentals.entity.RentalStatus.OVERDUE;
+import static site.bannabe.server.domain.rentals.entity.RentalStatus.RENTAL;
 
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
@@ -12,12 +18,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
-import static site.bannabe.server.domain.rentals.entity.QRentalHistory.rentalHistory;
-import static site.bannabe.server.domain.rentals.entity.QRentalItemTypes.rentalItemTypes;
-import static site.bannabe.server.domain.rentals.entity.QRentalItems.rentalItems;
 import site.bannabe.server.domain.rentals.entity.RentalHistory;
-import static site.bannabe.server.domain.rentals.entity.RentalStatus.OVERDUE;
-import static site.bannabe.server.domain.rentals.entity.RentalStatus.RENTAL;
 
 @Repository
 @RequiredArgsConstructor

--- a/server/src/main/java/site/bannabe/server/domain/rentals/repository/querydsl/CustomRentalItemRepository.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/repository/querydsl/CustomRentalItemRepository.java
@@ -1,0 +1,9 @@
+package site.bannabe.server.domain.rentals.repository.querydsl;
+
+import site.bannabe.server.domain.rentals.controller.response.RentalItemDetailResponse;
+
+public interface CustomRentalItemRepository {
+
+  RentalItemDetailResponse findRentalItemDetailBy(Long stationId, Long itemTypeId);
+
+}

--- a/server/src/main/java/site/bannabe/server/domain/rentals/repository/querydsl/CustomRentalItemRepositoryImpl.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/repository/querydsl/CustomRentalItemRepositoryImpl.java
@@ -1,0 +1,38 @@
+package site.bannabe.server.domain.rentals.repository.querydsl;
+
+import static site.bannabe.server.domain.rentals.entity.QRentalItemTypes.rentalItemTypes;
+import static site.bannabe.server.domain.rentals.entity.QRentalStationItems.rentalStationItems;
+import static site.bannabe.server.domain.rentals.entity.QRentalStations.rentalStations;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import site.bannabe.server.domain.rentals.controller.response.RentalItemDetailResponse;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomRentalItemRepositoryImpl implements CustomRentalItemRepository {
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  @Override
+  public RentalItemDetailResponse findRentalItemDetailBy(Long stationId, Long itemTypeId) {
+    return jpaQueryFactory.select(Projections.constructor(
+                              RentalItemDetailResponse.class,
+                              rentalItemTypes.name,
+                              rentalItemTypes.image,
+                              rentalItemTypes.category.stringValue(),
+                              rentalItemTypes.description,
+                              rentalItemTypes.price,
+                              rentalStationItems.stock
+                          ))
+                          .from(rentalStationItems)
+                          .join(rentalStationItems.rentalStation, rentalStations)
+                          .join(rentalStationItems.rentalItemType, rentalItemTypes)
+                          .where(rentalStations.id.eq(stationId)
+                                                  .and(rentalItemTypes.id.eq(itemTypeId)))
+                          .fetchOne();
+  }
+
+}

--- a/server/src/main/java/site/bannabe/server/domain/rentals/repository/querydsl/CustomRentalStationRepository.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/repository/querydsl/CustomRentalStationRepository.java
@@ -1,0 +1,10 @@
+package site.bannabe.server.domain.rentals.repository.querydsl;
+
+import java.util.List;
+import site.bannabe.server.domain.rentals.controller.response.RentalStationDetailResponse.RentalItemResponse;
+
+public interface CustomRentalStationRepository {
+
+  List<RentalItemResponse> findRentalStationDetailBy(Long stationId);
+
+}

--- a/server/src/main/java/site/bannabe/server/domain/rentals/repository/querydsl/CustomRentalStationRepositoryImpl.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/repository/querydsl/CustomRentalStationRepositoryImpl.java
@@ -1,0 +1,35 @@
+package site.bannabe.server.domain.rentals.repository.querydsl;
+
+import static site.bannabe.server.domain.rentals.entity.QRentalItemTypes.rentalItemTypes;
+import static site.bannabe.server.domain.rentals.entity.QRentalStationItems.rentalStationItems;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import site.bannabe.server.domain.rentals.controller.response.RentalStationDetailResponse.RentalItemResponse;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomRentalStationRepositoryImpl implements CustomRentalStationRepository {
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  @Override
+  public List<RentalItemResponse> findRentalStationDetailBy(Long stationId) {
+    return jpaQueryFactory.select(Projections.constructor(
+                              RentalItemResponse.class,
+                              rentalItemTypes.id,
+                              rentalItemTypes.name,
+                              rentalItemTypes.image,
+                              rentalItemTypes.category.stringValue(),
+                              rentalStationItems.stock
+                          ))
+                          .from(rentalStationItems)
+                          .join(rentalStationItems.rentalItemType, rentalItemTypes)
+                          .where(rentalStationItems.rentalStation.id.eq(stationId))
+                          .fetch();
+  }
+
+}

--- a/server/src/main/java/site/bannabe/server/domain/rentals/service/RentalStationService.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/service/RentalStationService.java
@@ -1,0 +1,39 @@
+package site.bannabe.server.domain.rentals.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.bannabe.server.domain.rentals.controller.response.RentalItemDetailResponse;
+import site.bannabe.server.domain.rentals.controller.response.RentalStationDetailResponse;
+import site.bannabe.server.domain.rentals.controller.response.RentalStationDetailResponse.RentalItemResponse;
+import site.bannabe.server.domain.rentals.controller.response.RentalStationSimpleResponse;
+import site.bannabe.server.domain.rentals.entity.RentalStations;
+import site.bannabe.server.domain.rentals.repository.RentalItemRepository;
+import site.bannabe.server.domain.rentals.repository.RentalStationRepository;
+
+@Service
+@RequiredArgsConstructor
+public class RentalStationService {
+
+  private final RentalStationRepository rentalStationRepository;
+  private final RentalItemRepository rentalItemRepository;
+
+  @Transactional(readOnly = true)
+  public RentalStationSimpleResponse getAllRentalStations() {
+    List<RentalStations> rentalStations = rentalStationRepository.findAll();
+    return RentalStationSimpleResponse.create(rentalStations);
+  }
+
+  @Transactional(readOnly = true)
+  public RentalStationDetailResponse getRentalStationDetail(Long stationId) {
+    List<RentalItemResponse> rentalItemResponses = rentalStationRepository.findRentalStationDetailBy(stationId);
+    return new RentalStationDetailResponse(rentalItemResponses);
+  }
+
+  @Transactional(readOnly = true)
+  public RentalItemDetailResponse getRentalItemDetail(Long stationId, Long itemTypeId) {
+    return rentalItemRepository.findRentalItemDetailBy(stationId, itemTypeId);
+  }
+
+}

--- a/server/src/main/java/site/bannabe/server/domain/users/entity/BookmarkStations.java
+++ b/server/src/main/java/site/bannabe/server/domain/users/entity/BookmarkStations.java
@@ -22,4 +22,10 @@ public class BookmarkStations extends BaseEntity {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "rental_station_id")
   private RentalStations rentalStation;
+
+  public BookmarkStations(Users user, RentalStations rentalStation) {
+    this.user = user;
+    this.rentalStation = rentalStation;
+  }
+
 }

--- a/server/src/main/java/site/bannabe/server/domain/users/repository/BookmarkStationRepository.java
+++ b/server/src/main/java/site/bannabe/server/domain/users/repository/BookmarkStationRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.lang.NonNull;
 import site.bannabe.server.domain.users.entity.BookmarkStations;
+import site.bannabe.server.domain.users.repository.querydsl.CustomBookmarkStationRepository;
 
 public interface BookmarkStationRepository extends JpaRepository<BookmarkStations, Long>, CustomBookmarkStationRepository {
 

--- a/server/src/main/java/site/bannabe/server/domain/users/repository/CustomBookmarkStationRepository.java
+++ b/server/src/main/java/site/bannabe/server/domain/users/repository/CustomBookmarkStationRepository.java
@@ -1,12 +1,16 @@
 package site.bannabe.server.domain.users.repository;
 
 import java.util.List;
+import site.bannabe.server.domain.rentals.entity.RentalStations;
 import site.bannabe.server.domain.users.controller.response.UserBookmarkStationsResponse.BookmarkStationResponse;
+import site.bannabe.server.domain.users.entity.Users;
 
 public interface CustomBookmarkStationRepository {
 
   List<BookmarkStationResponse> findBookmarkStationsBy(String email);
 
-  Boolean existsBookmarkByEmail(String email, Long bookmarkId);
+  boolean existsBookmarkByEmail(String email, Long bookmarkId);
+
+  boolean existsBookmarkByEmailAndStation(Users user, RentalStations station);
 
 }

--- a/server/src/main/java/site/bannabe/server/domain/users/repository/CustomBookmarkStationRepositoryImpl.java
+++ b/server/src/main/java/site/bannabe/server/domain/users/repository/CustomBookmarkStationRepositoryImpl.java
@@ -1,14 +1,17 @@
 package site.bannabe.server.domain.users.repository;
 
+import static site.bannabe.server.domain.rentals.entity.QRentalStations.rentalStations;
+import static site.bannabe.server.domain.users.entity.QBookmarkStations.bookmarkStations;
+import static site.bannabe.server.domain.users.entity.QUsers.users;
+
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
-import static site.bannabe.server.domain.rentals.entity.QRentalStations.rentalStations;
+import site.bannabe.server.domain.rentals.entity.RentalStations;
 import site.bannabe.server.domain.users.controller.response.UserBookmarkStationsResponse.BookmarkStationResponse;
-import static site.bannabe.server.domain.users.entity.QBookmarkStations.bookmarkStations;
-import static site.bannabe.server.domain.users.entity.QUsers.users;
+import site.bannabe.server.domain.users.entity.Users;
 
 @Repository
 @RequiredArgsConstructor
@@ -33,12 +36,22 @@ public class CustomBookmarkStationRepositoryImpl implements CustomBookmarkStatio
   }
 
   @Override
-  public Boolean existsBookmarkByEmail(String email, Long bookmarkId) {
+  public boolean existsBookmarkByEmail(String email, Long bookmarkId) {
     Integer findBookmark = jpaQueryFactory.selectOne()
                                           .from(bookmarkStations)
                                           .join(bookmarkStations.user, users)
                                           .where(bookmarkStations.id.eq(bookmarkId)
-                                                                    .and(bookmarkStations.user.email.eq(email)))
+                                                                    .and(users.email.eq(email)))
+                                          .fetchFirst();
+    return findBookmark != null;
+  }
+
+  @Override
+  public boolean existsBookmarkByEmailAndStation(Users user, RentalStations station) {
+    Integer findBookmark = jpaQueryFactory.selectOne()
+                                          .from(bookmarkStations)
+                                          .where(bookmarkStations.user.eq(user)
+                                                                      .and(bookmarkStations.rentalStation.eq(station)))
                                           .fetchFirst();
     return findBookmark != null;
   }

--- a/server/src/main/java/site/bannabe/server/domain/users/repository/querydsl/CustomBookmarkStationRepository.java
+++ b/server/src/main/java/site/bannabe/server/domain/users/repository/querydsl/CustomBookmarkStationRepository.java
@@ -1,4 +1,4 @@
-package site.bannabe.server.domain.users.repository;
+package site.bannabe.server.domain.users.repository.querydsl;
 
 import java.util.List;
 import site.bannabe.server.domain.rentals.entity.RentalStations;

--- a/server/src/main/java/site/bannabe/server/domain/users/repository/querydsl/CustomBookmarkStationRepositoryImpl.java
+++ b/server/src/main/java/site/bannabe/server/domain/users/repository/querydsl/CustomBookmarkStationRepositoryImpl.java
@@ -1,4 +1,4 @@
-package site.bannabe.server.domain.users.repository;
+package site.bannabe.server.domain.users.repository.querydsl;
 
 import static site.bannabe.server.domain.rentals.entity.QRentalStations.rentalStations;
 import static site.bannabe.server.domain.users.entity.QBookmarkStations.bookmarkStations;
@@ -32,6 +32,7 @@ public class CustomBookmarkStationRepositoryImpl implements CustomBookmarkStatio
                           .join(bookmarkStations.user, users)
                           .join(bookmarkStations.rentalStation, rentalStations)
                           .where(users.email.eq(email))
+                          .orderBy(rentalStations.name.asc())
                           .fetch();
   }
 

--- a/server/src/main/java/site/bannabe/server/domain/users/service/UserService.java
+++ b/server/src/main/java/site/bannabe/server/domain/users/service/UserService.java
@@ -114,7 +114,7 @@ public class UserService {
 
   @Transactional
   public void removeBookmarkStation(String email, Long bookmarkId) {
-    Boolean isUserBookmark = bookmarkStationRepository.existsBookmarkByEmail(email, bookmarkId);
+    boolean isUserBookmark = bookmarkStationRepository.existsBookmarkByEmail(email, bookmarkId);
     if (!isUserBookmark) {
       throw new BannabeServiceException(ErrorCode.BOOKMARK_NOT_EXIST);
     }

--- a/server/src/main/java/site/bannabe/server/global/exceptions/ErrorCode.java
+++ b/server/src/main/java/site/bannabe/server/global/exceptions/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
   REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "RefreshToken이 존재하지 않습니다."),
   AUTH_CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "인증 코드가 존재하지 않습니다."),
   BOOKMARK_NOT_EXIST(HttpStatus.NOT_FOUND, "북마크 정보가 일치하지 않습니다."),
+  RENTAL_STATION_NOT_FOUND(HttpStatus.NOT_FOUND, "대여소 정보가 존재하지 않습니다."),
 
   // 409 CONFLICT
   NEW_PASSWORD_MISMATCH(HttpStatus.CONFLICT, "새 비밀번호가 일치하지 않습니다."),
@@ -38,6 +39,7 @@ public enum ErrorCode {
   DUPLICATE_PASSWORD(HttpStatus.CONFLICT, "동일한 비밀번호로 변경할 수 없습니다."),
   AUTH_CODE_MISMATCH(HttpStatus.CONFLICT, "인증 코드가 일치하지 않습니다."),
   AUTH_CODE_ALREADY_VERIFIED(HttpStatus.CONFLICT, "이미 인증된 코드입니다."),
+  ALREADY_BOOKMARKED(HttpStatus.CONFLICT, "이미 즐겨찾기한 대여 스테이션입니다."),
 
   // 500 INTERNAL_SERVER_ERROR
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류입니다. 관리자에게 문의하세요."),

--- a/server/src/main/java/site/bannabe/server/global/security/auth/EndPoints.java
+++ b/server/src/main/java/site/bannabe/server/global/security/auth/EndPoints.java
@@ -16,6 +16,9 @@ public class EndPoints {
       new EndPoint(HttpMethod.POST, "/v1/auth/send-code"),
       new EndPoint(HttpMethod.POST, "/v1/auth/verify-code"),
       new EndPoint(HttpMethod.PUT, "/v1/auth/reset-password"),
+      new EndPoint(HttpMethod.GET, "/v1/stations"),
+      new EndPoint(HttpMethod.GET, "/v1/stations/{stationId}"),
+      new EndPoint(HttpMethod.GET, "/v1/stations/{stationId}/items/{itemTypeId}"),
       new EndPoint(HttpMethod.GET, "/notices/**"),
       new EndPoint(HttpMethod.GET, "/events/**")
   );


### PR DESCRIPTION
## 🔍 요약
- 스테이션 조회 API 구현
- 스테이션 상세정보 조회 API 구현
- 스테이션 대여물품 상세정보 조회 API 구현
- 스테이션 북마크 추가 API 구현

## #️⃣ 연관된 이슈
#10 

## 🛠️ 작업 내용
### 스테이션 조회 API `/v1/stations` `GET`
- DB에 저장되어있는 모든 대여 스테이션을 조회합니다.
- 응답 객체에 포함되는 데이터는 다음과 같습니다.
  - 스테이션 이름
  - 주소
  - 위도, 경도
  - 상태 (운영 중, 운영 종료, etc...)
  - 영업시간
  - 등급
  - 스테이션 식별값
- 사용자 위치 기반 주변 스테이션 조회는 클라이언트 레벨에서 제어할 수 있도록 모든 스테이션 데이터를 전달합니다.

### 스테이션 상세정보 조회 API `/v1/stations/{stationId}` `GET`
- 특정 대여 스테이션에서 대여할 수 있는 물품을 조회합니다.
- `PathVariable`인 `stationId`를 기반으로 대여가능 물품 타입을 조회합니다.
- 응답 객체에 포함되는 데이터는 다음과 같습니다.
  - 대여물품 타입 식별값
  - 대여물품 이름
  - 대여물품 이미지 url
  - 대여물품 카테고리
  - 대여물품 재고
- 클라이언트 레벨에서 categorizing과 검색을 구현할 수 있도록 모든 대여물품 데이터를 전달합니다.

### 대여물품 상세정보 조회 API `/v1/stations/{stationId}/items/{itemTypeId}` `GET`
- 특정 대여 스테이션 상세 페이지에서 특정 물품에 대한 정보를 조회합니다.
- `PathVariable`인 `stationId`와 `itemTypeId`를 기반으로 해당 물품에 대한 정보를 조회합니다.
- 응답 객체에 포함되는 데이터는 다음과 같습니다.
  - 대여물품 이름
  - 대여물품 이미지 url
  - 대여물품 카테고리
  - 대여물품 설명
  - 시간당 금액
  - 대여물품 재고

### 스테이션 북마크 추가 API `/v1/stations/{stataionId}/bookmark` `POST`
- 특정 스테이션을 북마크에 추가합니다.
- 로그인이 필요한 기능이므로, AccessToken이 없을 시 401에러를 응답하며 로그인페이지로 유도합니다.
- 사용자 식별값 `email`과 `PathVariable`인 `stationId`를 사용해 `Users` 와 `RentalStations` Entity를 조회합니다.
  - 해당 단계에서 NPE 발생 시 404 에러를 던집니다.
- 조회한 Entity를 기반으로 해당 대여 스테이션이 이미 북마크 되었는지 검증합니다.
- 중복 북마크가 아니라면 `BookmarkStations` Entity를 생성한 후, DB에 저장합니다. 

## 💬 To Other
- 스테이션 조회 API는 RentalStations 테이블의 row가 1000개 미만이라 가정하고 구현했기 때문에, 서비스 확장 시 리팩토링할 계획입니다.