### PR TITLE
Feature: 소셜 로그인 구현

### DIFF
--- a/server/src/main/java/site/bannabe/server/domain/users/controller/OAuth2Controller.java
+++ b/server/src/main/java/site/bannabe/server/domain/users/controller/OAuth2Controller.java
@@ -1,0 +1,24 @@
+package site.bannabe.server.domain.users.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import site.bannabe.server.domain.users.controller.request.OAuth2AccessTokenRequest;
+import site.bannabe.server.domain.users.service.OAuth2Service;
+import site.bannabe.server.global.type.TokenResponse;
+
+@RestController
+@RequiredArgsConstructor
+public class OAuth2Controller {
+
+  private final OAuth2Service oAuth2Service;
+
+  @PostMapping("/oauth2/login/{provider}")
+  public TokenResponse loginWithOAuth2(@PathVariable String provider,
+      @RequestBody OAuth2AccessTokenRequest oAuth2AccessToken) {
+    return oAuth2Service.processOAuth2Login(provider, oAuth2AccessToken.accessToken());
+  }
+
+}

--- a/server/src/main/java/site/bannabe/server/domain/users/controller/request/OAuth2AccessTokenRequest.java
+++ b/server/src/main/java/site/bannabe/server/domain/users/controller/request/OAuth2AccessTokenRequest.java
@@ -1,0 +1,7 @@
+package site.bannabe.server.domain.users.controller.request;
+
+public record OAuth2AccessTokenRequest(
+    String accessToken
+) {
+
+}

--- a/server/src/main/java/site/bannabe/server/domain/users/service/OAuth2Service.java
+++ b/server/src/main/java/site/bannabe/server/domain/users/service/OAuth2Service.java
@@ -1,0 +1,53 @@
+package site.bannabe.server.domain.users.service;
+
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClient;
+import site.bannabe.server.domain.users.entity.Users;
+import site.bannabe.server.domain.users.repository.UserRepository;
+import site.bannabe.server.global.jwt.GenerateToken;
+import site.bannabe.server.global.jwt.JwtService;
+import site.bannabe.server.global.security.auth.OAuth2ProviderRegistry;
+import site.bannabe.server.global.security.auth.OAuth2ProviderRegistry.OAuth2ProviderType;
+import site.bannabe.server.global.security.auth.OAuth2UserInfo;
+import site.bannabe.server.global.type.TokenResponse;
+
+@Service
+@RequiredArgsConstructor
+public class OAuth2Service {
+
+  private final UserRepository userRepository;
+  private final RestClient restClient;
+  private final JwtService jwtService;
+
+  @Transactional
+  public TokenResponse processOAuth2Login(String provider, String accessToken) {
+    OAuth2ProviderType oAuth2ProviderType = OAuth2ProviderRegistry.getType(provider);
+    Map<String, Object> attributes = restClient.get().uri(oAuth2ProviderType.USER_INFO_URL)
+                                               .headers(headers -> {
+                                                 headers.setBearerAuth(accessToken);
+                                                 headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+                                               })
+                                               .retrieve()
+                                               .body(new ParameterizedTypeReference<>() {
+                                               });
+    OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfo.from(oAuth2ProviderType, attributes);
+
+    return registerOrAuthenticateUser(oAuth2UserInfo);
+  }
+
+  private TokenResponse registerOrAuthenticateUser(OAuth2UserInfo oAuth2UserInfo) {
+    Users user = userRepository.findByEmail(oAuth2UserInfo.email()).orElseGet(() -> {
+      Users newUser = oAuth2UserInfo.toUser();
+      return userRepository.save(newUser);
+    });
+
+    GenerateToken token = jwtService.createJWT(user.getEmail(), user.getRole().getRoleKey());
+    return TokenResponse.create(token);
+  }
+
+}

--- a/server/src/main/java/site/bannabe/server/domain/users/service/OAuth2Service.java
+++ b/server/src/main/java/site/bannabe/server/domain/users/service/OAuth2Service.java
@@ -23,6 +23,7 @@ public class OAuth2Service {
   private final UserRepository userRepository;
   private final RestClient restClient;
   private final JwtService jwtService;
+  private final PasswordService passwordService;
 
   @Transactional
   public TokenResponse processOAuth2Login(String provider, String accessToken) {
@@ -43,6 +44,8 @@ public class OAuth2Service {
   private TokenResponse registerOrAuthenticateUser(OAuth2UserInfo oAuth2UserInfo) {
     Users user = userRepository.findByEmail(oAuth2UserInfo.email()).orElseGet(() -> {
       Users newUser = oAuth2UserInfo.toUser();
+      String encodedPassword = passwordService.encodePassword(newUser.getProviderType().name() + "_" + newUser.getEmail());
+      newUser.changePassword(encodedPassword);
       return userRepository.save(newUser);
     });
 

--- a/server/src/main/java/site/bannabe/server/global/security/auth/EndPoint.java
+++ b/server/src/main/java/site/bannabe/server/global/security/auth/EndPoint.java
@@ -25,7 +25,8 @@ public record EndPoint(
       new EndPoint(HttpMethod.GET, "/v1/payments/success"),
       new EndPoint(HttpMethod.GET, "/v1/payments/failure"),
       new EndPoint(HttpMethod.GET, "/payment-test"),
-      new EndPoint(HttpMethod.GET, "/payment-complete")
+      new EndPoint(HttpMethod.GET, "/payment-complete"),
+      new EndPoint(HttpMethod.POST, "/oauth2/login/{provider}")
   );
 
 }

--- a/server/src/main/java/site/bannabe/server/global/security/auth/OAuth2ProviderRegistry.java
+++ b/server/src/main/java/site/bannabe/server/global/security/auth/OAuth2ProviderRegistry.java
@@ -1,0 +1,38 @@
+package site.bannabe.server.global.security.auth;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+
+public abstract class OAuth2ProviderRegistry {
+
+  private static final Map<String, OAuth2ProviderType> PROVIDER_TYPE_MAP =
+      Collections.unmodifiableMap(
+          Arrays.stream(OAuth2ProviderType.values())
+                .collect(Collectors.toMap(type -> type.PROVIDER, Function.identity()))
+      );
+
+
+  public static OAuth2ProviderType getType(String provider) {
+    return Optional.ofNullable(PROVIDER_TYPE_MAP.get(provider)).orElseThrow();
+  }
+
+  @RequiredArgsConstructor
+  public enum OAuth2ProviderType {
+
+    KAKAO("kakao", "kakao_account", "email", "profile_image_url", "https://kapi.kakao.com/v2/user/me"),
+    GOOGLE("google", null, "email", "picture", "https://www.googleapis.com/oauth2/v3/userinfo");
+
+    public final String PROVIDER;
+    public final String ATTRIBUTES_FIELD;
+    public final String EMAIL_FIELD;
+    public final String IMAGE_FIELD;
+    public final String USER_INFO_URL;
+
+  }
+
+}

--- a/server/src/main/java/site/bannabe/server/global/security/auth/OAuth2UserInfo.java
+++ b/server/src/main/java/site/bannabe/server/global/security/auth/OAuth2UserInfo.java
@@ -1,0 +1,45 @@
+package site.bannabe.server.global.security.auth;
+
+import java.util.Map;
+import site.bannabe.server.domain.users.entity.ProviderType;
+import site.bannabe.server.domain.users.entity.Users;
+import site.bannabe.server.global.security.auth.OAuth2ProviderRegistry.OAuth2ProviderType;
+
+public record OAuth2UserInfo(
+    ProviderType providerType,
+    String email,
+    String profileImage
+) {
+
+  @SuppressWarnings("unchecked")
+  public static OAuth2UserInfo from(OAuth2ProviderType oauth2Type, Map<String, Object> attributes) {
+    ProviderType providerType = ProviderType.valueOf(oauth2Type.name());
+    String email;
+    String profileImage;
+
+    switch (oauth2Type) {
+      case KAKAO -> {
+        Map<String, Object> nestedAttributes = (Map<String, Object>) attributes.get(oauth2Type.ATTRIBUTES_FIELD);
+        Map<String, Object> profileAttributes = (Map<String, Object>) nestedAttributes.get("profile");
+        email = (String) nestedAttributes.get(oauth2Type.EMAIL_FIELD);
+        profileImage = (String) profileAttributes.get(oauth2Type.IMAGE_FIELD);
+      }
+      case GOOGLE -> {
+        email = (String) attributes.get(oauth2Type.EMAIL_FIELD);
+        profileImage = (String) attributes.get(oauth2Type.IMAGE_FIELD);
+      }
+      default -> throw new IllegalStateException("Unexpected value: " + oauth2Type);
+    }
+
+    return new OAuth2UserInfo(providerType, email, profileImage);
+  }
+
+  public Users toUser() {
+    return Users.builder()
+                .email(email)
+                .profileImage(profileImage)
+                .providerType(providerType)
+                .build();
+  }
+
+}


### PR DESCRIPTION
## 🔍  요약
- 구글, 카카오 소셜 로그인 구현

## #️⃣ 연관된 이슈
x

## 🛠️ 작업 내용
### 소셜 로그인 요청 `/oauth2/login/{provider}` `POST`
- OAuth2 AccessToken을 사용해 사용자 정보를 조회하고, 소셜 로그인을 진행합니다.
- OAuth2 Provider에 맞는 User Info URI에 AccessToken을 사용해 사용자 정보를 조회합니다.
- `OAuth2ProviderType`를 사용해 `OAuth2UserInfo`를 구성합니다.
- `OAuth2UserInfo.email`로 DB에서 Users Entity를 조회합니다.
  - 비 회원이라면 회원가입 후 JWT를 발급해 응답합니다.
  - 회원이라면 회원가입을 스킵, JWT를 발급합니다.

## 💬 To Other

리뷰어에게 남기고 싶은 말을 작성해주세요.
