### PR TITLE
Test: 테스트 코드 추가 및 리팩토링

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Reusable Build & Test
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
+
+      - name: Grant execute permission to Gradlew
+        run: chmod +x gradlew
+        working-directory: ./server
+
+      - name: Build With Gradle
+        run: ./gradlew build --info
+        working-directory: ./server

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,5 +26,5 @@ jobs:
         working-directory: ./server
 
       - name: Build With Gradle
-        run: ./gradlew build --info
+        run: ./gradlew build
         working-directory: ./server

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,11 +11,13 @@ on:
 
 jobs:
   build:
+    if: github.event.action == 'opened' || github.event.action == 'synchronize'
     uses: ./.github/workflows/build.yml
     permissions:
       contents: read
 
   slack_nofitication:
+    needs: build
     runs-on: ubuntu-22.04
     steps:
       - name: Send Slack Notification on PR Opened

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,4 +1,4 @@
-name: Slack Notification
+name: Pull Request Workflow (Build & Slack Notification)
 
 on:
   pull_request:
@@ -10,8 +10,13 @@ on:
       - develop
 
 jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    permissions:
+      contents: read
+
   slack_nofitication:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Send Slack Notification on PR Opened
         if: github.event.action == 'opened'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,16 @@
+name: Push Workflow (Build & Test)
+
+on:
+  push:
+    branches:
+      - feature/**
+      - fix/**
+      - chore/**
+      - refactor/**
+      - test/**
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    permissions:
+      contents: read

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,12 +2,9 @@ name: Push Workflow (Build & Test)
 
 on:
   push:
-    branches:
-      - feature/**
-      - fix/**
-      - chore/**
-      - refactor/**
-      - test/**
+    branches-ignore:
+      - main
+      - develop
 
 jobs:
   build:

--- a/server/src/main/java/site/bannabe/server/domain/payments/service/PaymentService.java
+++ b/server/src/main/java/site/bannabe/server/domain/payments/service/PaymentService.java
@@ -60,7 +60,7 @@ public class PaymentService {
 
   private RentalHistory createRentalHistory(String email, OrderInfo orderInfo,
       TossPaymentConfirmResponse paymentConfirmResponse, RentalItems rentalItem) {
-    Users user = userRepository.findByEmail(email).orElseThrow(() -> new BannabeServiceException(ErrorCode.USER_NOT_FOUND));
+    Users user = userRepository.findByEmail(email);
     return RentalHistory.create(rentalItem, user, orderInfo, paymentConfirmResponse.approvedAt());
   }
 

--- a/server/src/main/java/site/bannabe/server/domain/rentals/service/RentalStationService.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/service/RentalStationService.java
@@ -51,7 +51,7 @@ public class RentalStationService {
                                                           .orElseThrow(() ->
                                                               new BannabeServiceException(ErrorCode.RENTAL_STATION_NOT_FOUND));
 
-    boolean isAlreadyBookmarked = bookmarkStationRepository.existsBookmarkByEmailAndStation(user, rentalStation);
+    boolean isAlreadyBookmarked = bookmarkStationRepository.existsByUserAndStation(user, rentalStation);
     if (isAlreadyBookmarked) {
       throw new BannabeServiceException(ErrorCode.ALREADY_BOOKMARKED);
     }

--- a/server/src/main/java/site/bannabe/server/domain/rentals/service/RentalStationService.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/service/RentalStationService.java
@@ -46,7 +46,7 @@ public class RentalStationService {
 
   @Transactional
   public void bookmarkRentalStation(Long stationId, String email) {
-    Users user = userRepository.findByEmail(email).orElseThrow(() -> new BannabeServiceException(ErrorCode.USER_NOT_FOUND));
+    Users user = userRepository.findByEmail(email);
     RentalStations rentalStation = rentalStationRepository.findById(stationId)
                                                           .orElseThrow(() ->
                                                               new BannabeServiceException(ErrorCode.RENTAL_STATION_NOT_FOUND));

--- a/server/src/main/java/site/bannabe/server/domain/users/repository/UserRepository.java
+++ b/server/src/main/java/site/bannabe/server/domain/users/repository/UserRepository.java
@@ -1,15 +1,13 @@
 package site.bannabe.server.domain.users.repository;
 
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import site.bannabe.server.domain.users.entity.Users;
+import site.bannabe.server.domain.users.repository.querydsl.CustomUserRepository;
 
-public interface UserRepository extends JpaRepository<Users, Long> {
+public interface UserRepository extends JpaRepository<Users, Long>, CustomUserRepository {
 
   Boolean existsByEmail(String email);
 
   Boolean existsByNickname(String nickname);
-
-  Optional<Users> findByEmail(String email);
 
 }

--- a/server/src/main/java/site/bannabe/server/domain/users/repository/querydsl/CustomBookmarkStationRepository.java
+++ b/server/src/main/java/site/bannabe/server/domain/users/repository/querydsl/CustomBookmarkStationRepository.java
@@ -9,8 +9,8 @@ public interface CustomBookmarkStationRepository {
 
   List<BookmarkStationResponse> findBookmarkStationsBy(String email);
 
-  boolean existsBookmarkByEmail(String email, Long bookmarkId);
+  boolean existsByEmailAndId(String email, Long bookmarkId);
 
-  boolean existsBookmarkByEmailAndStation(Users user, RentalStations station);
+  boolean existsByUserAndStation(Users user, RentalStations station);
 
 }

--- a/server/src/main/java/site/bannabe/server/domain/users/repository/querydsl/CustomBookmarkStationRepositoryImpl.java
+++ b/server/src/main/java/site/bannabe/server/domain/users/repository/querydsl/CustomBookmarkStationRepositoryImpl.java
@@ -37,7 +37,7 @@ public class CustomBookmarkStationRepositoryImpl implements CustomBookmarkStatio
   }
 
   @Override
-  public boolean existsBookmarkByEmail(String email, Long bookmarkId) {
+  public boolean existsByEmailAndId(String email, Long bookmarkId) {
     Integer findBookmark = jpaQueryFactory.selectOne()
                                           .from(bookmarkStations)
                                           .join(bookmarkStations.user, users)
@@ -48,7 +48,7 @@ public class CustomBookmarkStationRepositoryImpl implements CustomBookmarkStatio
   }
 
   @Override
-  public boolean existsBookmarkByEmailAndStation(Users user, RentalStations station) {
+  public boolean existsByUserAndStation(Users user, RentalStations station) {
     Integer findBookmark = jpaQueryFactory.selectOne()
                                           .from(bookmarkStations)
                                           .where(bookmarkStations.user.eq(user)

--- a/server/src/main/java/site/bannabe/server/domain/users/repository/querydsl/CustomUserRepository.java
+++ b/server/src/main/java/site/bannabe/server/domain/users/repository/querydsl/CustomUserRepository.java
@@ -1,0 +1,9 @@
+package site.bannabe.server.domain.users.repository.querydsl;
+
+import site.bannabe.server.domain.users.entity.Users;
+
+public interface CustomUserRepository {
+
+  Users findByEmail(String email);
+  
+}

--- a/server/src/main/java/site/bannabe/server/domain/users/repository/querydsl/CustomUserRepositoryImpl.java
+++ b/server/src/main/java/site/bannabe/server/domain/users/repository/querydsl/CustomUserRepositoryImpl.java
@@ -1,0 +1,28 @@
+package site.bannabe.server.domain.users.repository.querydsl;
+
+import static site.bannabe.server.domain.users.entity.QUsers.users;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import site.bannabe.server.domain.users.entity.Users;
+import site.bannabe.server.global.exceptions.BannabeServiceException;
+import site.bannabe.server.global.exceptions.ErrorCode;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomUserRepositoryImpl implements CustomUserRepository {
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  @Override
+  public Users findByEmail(String email) {
+    Users user = jpaQueryFactory.selectFrom(users)
+                                .where(users.email.eq(email))
+                                .fetchFirst();
+
+    return Optional.ofNullable(user).orElseThrow(() -> new BannabeServiceException(ErrorCode.USER_NOT_FOUND));
+  }
+
+}

--- a/server/src/main/java/site/bannabe/server/domain/users/service/AuthService.java
+++ b/server/src/main/java/site/bannabe/server/domain/users/service/AuthService.java
@@ -34,7 +34,7 @@ public class AuthService {
   public void registerUser(UserRegisterRequest registerRequest) {
     Boolean isDuplicateEmail = userRepository.existsByEmail(registerRequest.email());
     if (isDuplicateEmail) {
-      throw new IllegalArgumentException("이미 사용중인 이메일입니다.");
+      throw new BannabeServiceException(ErrorCode.DUPLICATE_EMAIL);
     }
 
     String encodedPassword = passwordService.encodePassword(registerRequest.password());
@@ -82,6 +82,9 @@ public class AuthService {
     String newPasswordConfirm = resetPasswordRequest.newPasswordConfirm();
 
     AuthCode savedAuthCode = authCodeService.findAuthCode(email);
+    if (!savedAuthCode.isVerified()) {
+      throw new BannabeServiceException(ErrorCode.AUTH_CODE_NOT_VERIFIED);
+    }
     validateAuthCode(resetPasswordRequest.authCode(), savedAuthCode.getAuthCode());
 
     passwordService.validateNewPassword(newPassword, newPasswordConfirm);

--- a/server/src/main/java/site/bannabe/server/domain/users/service/AuthService.java
+++ b/server/src/main/java/site/bannabe/server/domain/users/service/AuthService.java
@@ -89,7 +89,7 @@ public class AuthService {
 
     passwordService.validateNewPassword(newPassword, newPasswordConfirm);
 
-    Users findUser = userRepository.findByEmail(email).orElseThrow(() -> new BannabeServiceException(ErrorCode.USER_NOT_FOUND));
+    Users findUser = userRepository.findByEmail(email);
 
     passwordService.validateReusedPassword(newPassword, findUser.getPassword());
 

--- a/server/src/main/java/site/bannabe/server/domain/users/service/UserService.java
+++ b/server/src/main/java/site/bannabe/server/domain/users/service/UserService.java
@@ -1,11 +1,13 @@
 package site.bannabe.server.domain.users.service;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -93,6 +95,9 @@ public class UserService {
   @Transactional
   public List<RentalHistoryResponse> getActiveRentalHistory(String email) {
     List<RentalHistory> rentalHistories = rentalHistoryRepository.findActiveRentalsBy(email);
+    if (rentalHistories.isEmpty()) {
+      return Collections.emptyList();
+    }
     LocalDateTime now = LocalDateTime.now();
     rentalHistories.forEach(rentalHistory -> rentalHistory.validateOverdue(now));
     return rentalHistories.stream().map(RentalHistoryResponse::of).toList();
@@ -101,6 +106,9 @@ public class UserService {
   @Transactional
   public Page<RentalHistoryResponse> getRentalHistory(String email, Pageable pageable) {
     Page<RentalHistory> rentalHistories = rentalHistoryRepository.findAllRentalsBy(email, pageable);
+    if (rentalHistories.isEmpty()) {
+      return new PageImpl<>(Collections.emptyList());
+    }
     LocalDateTime now = LocalDateTime.now();
     rentalHistories.forEach(rentalHistory -> rentalHistory.validateOverdue(now));
     return rentalHistories.map(RentalHistoryResponse::of);

--- a/server/src/main/java/site/bannabe/server/domain/users/service/UserService.java
+++ b/server/src/main/java/site/bannabe/server/domain/users/service/UserService.java
@@ -122,7 +122,7 @@ public class UserService {
 
   @Transactional
   public void removeBookmarkStation(String email, Long bookmarkId) {
-    boolean isUserBookmark = bookmarkStationRepository.existsBookmarkByEmail(email, bookmarkId);
+    boolean isUserBookmark = bookmarkStationRepository.existsByEmailAndId(email, bookmarkId);
     if (!isUserBookmark) {
       throw new BannabeServiceException(ErrorCode.BOOKMARK_NOT_EXIST);
     }

--- a/server/src/main/java/site/bannabe/server/domain/users/service/UserService.java
+++ b/server/src/main/java/site/bannabe/server/domain/users/service/UserService.java
@@ -48,7 +48,7 @@ public class UserService {
 
     passwordService.validateNewPassword(newPassword, newPasswordConfirm);
 
-    Users findUser = userRepository.findByEmail(email).orElseThrow(() -> new BannabeServiceException(ErrorCode.USER_NOT_FOUND));
+    Users findUser = userRepository.findByEmail(email);
 
     passwordService.validateCurrentPassword(currentPassword, findUser.getPassword());
     passwordService.validateReusedPassword(newPassword, findUser.getPassword());
@@ -64,17 +64,13 @@ public class UserService {
       throw new BannabeServiceException(ErrorCode.DUPLICATE_NICKNAME);
     }
 
-    userRepository.findByEmail(email).ifPresentOrElse(
-        user -> user.changeNickname(nicknameRequest.nickname()),
-        () -> {
-          throw new BannabeServiceException(ErrorCode.USER_NOT_FOUND);
-        }
-    );
+    Users user = userRepository.findByEmail(email);
+    user.changeNickname(nicknameRequest.nickname());
   }
 
   @Transactional
   public void changeProfileImage(String email, UserChangeProfileImageRequest changeProfileImageRequest) {
-    Users user = userRepository.findByEmail(email).orElseThrow(() -> new BannabeServiceException(ErrorCode.USER_NOT_FOUND));
+    Users user = userRepository.findByEmail(email);
     String currentProfileImage = user.getProfileImage();
 
     String newProfileImage = changeProfileImageRequest.imageUrl();

--- a/server/src/main/java/site/bannabe/server/global/api/OAuth2ApiClient.java
+++ b/server/src/main/java/site/bannabe/server/global/api/OAuth2ApiClient.java
@@ -1,0 +1,30 @@
+package site.bannabe.server.global.api;
+
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import site.bannabe.server.global.security.auth.OAuth2ProviderRegistry.OAuth2ProviderType;
+import site.bannabe.server.global.security.auth.OAuth2UserInfo;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2ApiClient {
+
+  private final RestClient restClient;
+
+  public OAuth2UserInfo getOAuth2UserInfo(OAuth2ProviderType providerType, String accessToken) {
+    Map<String, Object> attributes = restClient.get().uri(providerType.USER_INFO_URL)
+                                               .headers(headers -> {
+                                                 headers.setBearerAuth(accessToken);
+                                                 headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+                                               })
+                                               .retrieve()
+                                               .body(new ParameterizedTypeReference<>() {
+                                               });
+    return OAuth2UserInfo.from(providerType, attributes);
+  }
+
+}

--- a/server/src/main/java/site/bannabe/server/global/api/TossPaymentApiClient.java
+++ b/server/src/main/java/site/bannabe/server/global/api/TossPaymentApiClient.java
@@ -1,7 +1,6 @@
 package site.bannabe.server.global.api;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -9,7 +8,6 @@ import org.springframework.web.client.RestClient;
 import site.bannabe.server.domain.payments.controller.request.PaymentConfirmRequest;
 import site.bannabe.server.global.utils.JsonUtils;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class TossPaymentApiClient {

--- a/server/src/main/java/site/bannabe/server/global/exceptions/ErrorCode.java
+++ b/server/src/main/java/site/bannabe/server/global/exceptions/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
   TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
   INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
   INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "RefreshToken이 유효하지 않습니다."),
+  TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),
 
   // 403 FORBIDDEN
   FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),

--- a/server/src/main/java/site/bannabe/server/global/exceptions/ErrorCode.java
+++ b/server/src/main/java/site/bannabe/server/global/exceptions/ErrorCode.java
@@ -39,10 +39,12 @@ public enum ErrorCode {
   // 409 CONFLICT
   NEW_PASSWORD_MISMATCH(HttpStatus.CONFLICT, "새 비밀번호가 일치하지 않습니다."),
   PASSWORD_MISMATCH(HttpStatus.CONFLICT, "비밀번호가 일치하지 않습니다."),
+  DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 사용중인 이메일입니다."),
   DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 사용중인 닉네임입니다."),
   DUPLICATE_PASSWORD(HttpStatus.CONFLICT, "동일한 비밀번호로 변경할 수 없습니다."),
   AUTH_CODE_MISMATCH(HttpStatus.CONFLICT, "인증 코드가 일치하지 않습니다."),
   AUTH_CODE_ALREADY_VERIFIED(HttpStatus.CONFLICT, "이미 인증된 코드입니다."),
+  AUTH_CODE_NOT_VERIFIED(HttpStatus.CONFLICT, "인증 코드가 검증되지 않았습니다."),
   ALREADY_BOOKMARKED(HttpStatus.CONFLICT, "이미 즐겨찾기한 대여 스테이션입니다."),
   AMOUNT_MISMATCH(HttpStatus.CONFLICT, "금액이 일치하지 않습니다."),
   LOCK_CONFLICT(HttpStatus.CONFLICT, "현재 요청이 많아 처리가 지연되고 있습니다. 다시 시도해주세요."),

--- a/server/src/main/java/site/bannabe/server/global/jwt/JwtProvider.java
+++ b/server/src/main/java/site/bannabe/server/global/jwt/JwtProvider.java
@@ -46,7 +46,7 @@ public class JwtProvider {
 
   public void verifyToken(String token) {
     if (Objects.isNull(token)) {
-      throw new BannabeAuthenticationException(ErrorCode.INVALID_TOKEN);
+      throw new BannabeAuthenticationException(ErrorCode.TOKEN_NOT_FOUND);
     }
     try {
       parser.parseSignedClaims(token);

--- a/server/src/main/java/site/bannabe/server/global/security/auth/EndPoint.java
+++ b/server/src/main/java/site/bannabe/server/global/security/auth/EndPoint.java
@@ -2,6 +2,7 @@ package site.bannabe.server.global.security.auth;
 
 import java.util.List;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 public record EndPoint(
     HttpMethod method,
@@ -28,5 +29,13 @@ public record EndPoint(
       new EndPoint(HttpMethod.GET, "/payment-complete"),
       new EndPoint(HttpMethod.POST, "/oauth2/login/{provider}")
   );
+
+  public static final List<AntPathRequestMatcher> PERMIT_ALL_MATCHERS = PERMIT_ALL.stream()
+                                                                                  .map(EndPoint::toMatcher)
+                                                                                  .toList();
+
+  private AntPathRequestMatcher toMatcher() {
+    return AntPathRequestMatcher.antMatcher(this.method(), this.pattern());
+  }
 
 }

--- a/server/src/main/java/site/bannabe/server/global/security/filter/JwtAuthenticationFilter.java
+++ b/server/src/main/java/site/bannabe/server/global/security/filter/JwtAuthenticationFilter.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.filter.OncePerRequestFilter;
 import site.bannabe.server.global.jwt.JwtService;
+import site.bannabe.server.global.security.auth.EndPoint;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -20,17 +21,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
       throws ServletException, IOException {
     String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
-
-    if (authHeader == null || !authHeader.startsWith(BEARER_PREFIX)) {
-      filterChain.doFilter(request, response);
-      return;
-    }
-
     String accessToken = authHeader.substring(BEARER_PREFIX.length());
 
     jwtService.validateToken(accessToken);
     jwtService.saveAuthentication(accessToken);
     filterChain.doFilter(request, response);
+  }
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+    return EndPoint.PERMIT_ALL_MATCHERS.stream().anyMatch(matcher -> matcher.matches(request));
   }
 
 }

--- a/server/src/main/java/site/bannabe/server/global/security/service/CustomUserDetailsService.java
+++ b/server/src/main/java/site/bannabe/server/global/security/service/CustomUserDetailsService.java
@@ -7,7 +7,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import site.bannabe.server.domain.users.entity.Users;
 import site.bannabe.server.domain.users.repository.UserRepository;
-import site.bannabe.server.global.exceptions.ErrorCode;
+import site.bannabe.server.global.exceptions.BannabeServiceException;
 import site.bannabe.server.global.security.auth.PrincipalDetails;
 
 @Service
@@ -18,9 +18,12 @@ public class CustomUserDetailsService implements UserDetailsService {
 
   @Override
   public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-    Users user = userRepository.findByEmail(username)
-                               .orElseThrow(() -> new UsernameNotFoundException(ErrorCode.USER_NOT_FOUND.getMessage()));
-    return PrincipalDetails.create(user);
+    try {
+      Users user = userRepository.findByEmail(username);
+      return PrincipalDetails.create(user);
+    } catch (BannabeServiceException e) {
+      throw new UsernameNotFoundException(e.getErrorCode().getMessage());
+    }
   }
 
 }

--- a/server/src/main/resources/schema.sql
+++ b/server/src/main/resources/schema.sql
@@ -20,10 +20,10 @@ SET FOREIGN_KEY_CHECKS = 1;
 CREATE TABLE users
 (
     id            BIGINT PRIMARY KEY                                             NOT NULL AUTO_INCREMENT,
-    email         VARCHAR(255),
+    email         VARCHAR(255) UNIQUE,
     password      VARCHAR(255),
     profile_image VARCHAR(255),
-    nickname      VARCHAR(255),
+    nickname      VARCHAR(255) UNIQUE,
     role          VARCHAR(255),
     provider_type VARCHAR(255),
     create_at     DATETIME DEFAULT CURRENT_TIMESTAMP                             NOT NULL,

--- a/server/src/test/java/site/bannabe/server/domain/payments/service/PaymentLockServiceTest.java
+++ b/server/src/test/java/site/bannabe/server/domain/payments/service/PaymentLockServiceTest.java
@@ -35,7 +35,7 @@ class PaymentLockServiceTest extends AbstractTestContainers {
   private PaymentLockService paymentLockService;
 
   @Autowired
-  private RentalStockService rentalStockService;
+  private TestRentalStockService testRentalStockService;
 
   @Autowired
   private RentalStationItemRepository rentalStationItemRepository;
@@ -91,7 +91,7 @@ class PaymentLockServiceTest extends AbstractTestContainers {
     for (int i = 0; i < threadSize; i++) {
       executorService.execute(() -> {
         try {
-          rentalStockService.decreaseStock(rentalItems);
+          testRentalStockService.decreaseStock(rentalItems);
         } finally {
           latch.countDown();
         }

--- a/server/src/test/java/site/bannabe/server/domain/payments/service/PaymentServiceTest.java
+++ b/server/src/test/java/site/bannabe/server/domain/payments/service/PaymentServiceTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -94,7 +93,7 @@ class PaymentServiceTest {
     given(orderInfoService.findOrderInfoBy(confirmRequest.orderId())).willReturn(orderInfo);
     given(tossApiClient.confirmPaymentRequest(confirmRequest)).willReturn(confirmResponse);
     given(rentalItemRepository.findByToken(orderInfo.getRentalItemToken())).willReturn(mockItem);
-    given(userRepository.findByEmail(email)).willReturn(Optional.of(mockUser));
+    given(userRepository.findByEmail(email)).willReturn(mockUser);
     given(mockItem.getCurrentStation()).willReturn(mockStation);
 
     //when

--- a/server/src/test/java/site/bannabe/server/domain/payments/service/PaymentServiceTest.java
+++ b/server/src/test/java/site/bannabe/server/domain/payments/service/PaymentServiceTest.java
@@ -1,0 +1,140 @@
+package site.bannabe.server.domain.payments.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import site.bannabe.server.domain.payments.controller.request.PaymentCalculateRequest;
+import site.bannabe.server.domain.payments.controller.request.PaymentConfirmRequest;
+import site.bannabe.server.domain.payments.controller.response.PaymentCalculateResponse;
+import site.bannabe.server.domain.payments.controller.response.RentalHistoryTokenResponse;
+import site.bannabe.server.domain.payments.entity.PaymentMethod;
+import site.bannabe.server.domain.payments.entity.PaymentType;
+import site.bannabe.server.domain.payments.entity.RentalPayments;
+import site.bannabe.server.domain.payments.repository.RentalPaymentRepository;
+import site.bannabe.server.domain.rentals.entity.RentalItems;
+import site.bannabe.server.domain.rentals.entity.RentalStations;
+import site.bannabe.server.domain.rentals.repository.RentalItemRepository;
+import site.bannabe.server.domain.users.entity.Users;
+import site.bannabe.server.domain.users.repository.UserRepository;
+import site.bannabe.server.global.api.TossPaymentApiClient;
+import site.bannabe.server.global.api.TossPaymentConfirmResponse;
+import site.bannabe.server.global.api.TossPaymentConfirmResponse.ReceiptInfo;
+import site.bannabe.server.global.exceptions.BannabeServiceException;
+import site.bannabe.server.global.exceptions.ErrorCode;
+import site.bannabe.server.global.type.OrderInfo;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentServiceTest {
+
+  private final String rentalItemToken = "rentalItemToken";
+  private final String email = "test@test.com";
+  private final Integer rentalTime = 1;
+  private final Integer amount = 1000;
+  private final String orderId = "orderId";
+  private final String paymentKey = "paymentKey";
+  private final PaymentConfirmRequest confirmRequest = new PaymentConfirmRequest(paymentKey, amount, orderId);
+
+  @InjectMocks
+  private PaymentService paymentService;
+  @Mock
+  private RentalItemRepository rentalItemRepository;
+  @Mock
+  private RentalPaymentRepository rentalPaymentRepository;
+  @Mock
+  private UserRepository userRepository;
+  @Mock
+  private TossPaymentApiClient tossApiClient;
+  @Mock
+  private OrderInfoService orderInfoService;
+  @Mock
+  private PaymentLockService paymentLockService;
+
+  @Test
+  @DisplayName("최종 결제 금액 계산 후 데이터 응답")
+  void calculateAmount() {
+    //given
+    Integer rentalItemPrice = 1000;
+    PaymentCalculateRequest request = new PaymentCalculateRequest(rentalItemToken, rentalTime);
+    given(rentalItemRepository.findRentalItemPrice(rentalItemToken)).willReturn(rentalItemPrice);
+
+    //when
+    PaymentCalculateResponse response = paymentService.calculateAmount(request);
+
+    //then
+    assertThat(response).isNotNull()
+                        .extracting("rentalItemToken", "pricePerHour", "rentalTime", "amount")
+                        .containsExactly(rentalItemToken, rentalItemPrice, rentalTime, rentalItemPrice * rentalTime);
+  }
+
+  @Test
+  @DisplayName("결제 승인 후 대여내역 생성 및 결제정보 저장, 대여내역 토큰 응답, 모든 메서드 정상 호출")
+  void confirmPayment() {
+    //given
+    PaymentType paymentType = PaymentType.RENT;
+    OrderInfo orderInfo = new OrderInfo(rentalItemToken, rentalTime, amount, paymentType);
+    TossPaymentConfirmResponse confirmResponse = new TossPaymentConfirmResponse(paymentKey, PaymentMethod.CARD, orderId,
+        "충전기/1시간", amount, LocalDateTime.now(), new ReceiptInfo("receiptUrl"));
+    RentalItems mockItem = mock(RentalItems.class);
+    RentalStations mockStation = mock(RentalStations.class);
+    Users mockUser = mock(Users.class);
+
+    given(orderInfoService.findOrderInfoBy(confirmRequest.orderId())).willReturn(orderInfo);
+    given(tossApiClient.confirmPaymentRequest(confirmRequest)).willReturn(confirmResponse);
+    given(rentalItemRepository.findByToken(orderInfo.getRentalItemToken())).willReturn(mockItem);
+    given(userRepository.findByEmail(email)).willReturn(Optional.of(mockUser));
+    given(mockItem.getCurrentStation()).willReturn(mockStation);
+
+    //when
+    RentalHistoryTokenResponse response = paymentService.confirmPayment(email, confirmRequest);
+
+    //then
+    assertThat(response).isNotNull()
+                        .extracting(RentalHistoryTokenResponse::rentalHistoryToken).asString()
+                        .startsWith("RH_")
+                        .hasSize(13);
+
+    verify(orderInfoService).findOrderInfoBy(confirmRequest.orderId());
+    verify(tossApiClient).confirmPaymentRequest(confirmRequest);
+    verify(rentalItemRepository).findByToken(orderInfo.getRentalItemToken());
+    verify(userRepository).findByEmail(email);
+    verify(rentalPaymentRepository).save(any(RentalPayments.class));
+    verify(paymentLockService).decreaseStock(mockItem);
+    verify(mockItem).rentOut();
+    verify(orderInfoService).removeOrderInfo(confirmRequest.orderId());
+  }
+
+  @Test
+  @DisplayName("주문정보 / 결제요청 간 금액 불일치 시 예외 발생")
+  void mismatchAmount() {
+    //given
+    PaymentType paymentType = PaymentType.RENT;
+    OrderInfo orderInfo = new OrderInfo(rentalItemToken, rentalTime, 2000, paymentType);
+    given(orderInfoService.findOrderInfoBy(confirmRequest.orderId())).willReturn(orderInfo);
+
+    //when then
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> paymentService.confirmPayment(email, confirmRequest))
+        .withMessage(ErrorCode.AMOUNT_MISMATCH.getMessage());
+
+    verify(tossApiClient, never()).confirmPaymentRequest(confirmRequest);
+    verify(rentalItemRepository, never()).findByToken(rentalItemToken);
+    verify(userRepository, never()).findByEmail(email);
+    verify(rentalPaymentRepository, never()).save(any(RentalPayments.class));
+    verify(paymentLockService, never()).decreaseStock(any(RentalItems.class));
+    verify(orderInfoService, never()).removeOrderInfo(confirmRequest.orderId());
+  }
+
+}

--- a/server/src/test/java/site/bannabe/server/domain/payments/service/PaymentViewServiceTest.java
+++ b/server/src/test/java/site/bannabe/server/domain/payments/service/PaymentViewServiceTest.java
@@ -1,0 +1,112 @@
+package site.bannabe.server.domain.payments.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import site.bannabe.server.domain.payments.controller.response.PaymentInitializeResponse;
+import site.bannabe.server.domain.payments.entity.PaymentType;
+import site.bannabe.server.domain.rentals.entity.RentalItemTypes;
+import site.bannabe.server.domain.rentals.entity.RentalItems;
+import site.bannabe.server.domain.rentals.repository.RentalItemRepository;
+import site.bannabe.server.global.exceptions.BannabeServiceException;
+import site.bannabe.server.global.exceptions.ErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentViewServiceTest {
+
+  @InjectMocks
+  private PaymentViewService paymentViewService;
+  @Mock
+  private RentalItemRepository rentalItemRepository;
+  @Mock
+  private OrderInfoService orderInfoService;
+
+  @BeforeEach
+  void setup() {
+    ReflectionTestUtils.setField(paymentViewService, "apiKey", "test");
+  }
+
+  @Test
+  @DisplayName("결제 요청 데이터 생성 성공")
+  void getPaymentRequest() {
+    //given
+    String rentalItemToken = "rentalItemToken";
+    Integer rentalTime = 1;
+    PaymentType paymentType = PaymentType.RENT;
+    String rentalItemName = "rentalItemName";
+    Integer rentalItemPrice = 1000;
+    String orderName = rentalItemName + "/" + rentalTime + "시간";
+    RentalItems mockItems = mock(RentalItems.class);
+    RentalItemTypes mockItemTypes = mock(RentalItemTypes.class);
+
+    given(orderInfoService.isExistOrderInfo(rentalItemToken)).willReturn(false);
+    given(rentalItemRepository.findByToken(rentalItemToken)).willReturn(mockItems);
+    given(mockItems.getRentalItemType()).willReturn(mockItemTypes);
+    given(mockItemTypes.getName()).willReturn(rentalItemName);
+    given(mockItemTypes.getPrice()).willReturn(rentalItemPrice);
+
+    //when
+    PaymentInitializeResponse paymentRequest = paymentViewService.getPaymentRequest(rentalItemToken, rentalTime, paymentType);
+
+    //then
+    assertThat(paymentRequest).isNotNull()
+                              .extracting("apiKey", "amount", "currency", "orderName")
+                              .containsExactly("test", rentalItemPrice * rentalTime, "KRW", orderName);
+    verify(orderInfoService).saveOrderInfo(
+        anyString(), eq(rentalItemToken), eq(rentalTime), eq(rentalItemPrice * rentalTime), eq(paymentType)
+    );
+  }
+
+  @Test
+  @DisplayName("해당 물품에 대한 주문정보가 존재하면 예외 발생")
+  void isExistOrderInfo() {
+    //given
+    String rentalItemToken = "rentalItemToken";
+    Integer rentalTime = 1;
+    PaymentType paymentType = PaymentType.RENT;
+    given(orderInfoService.isExistOrderInfo(rentalItemToken)).willReturn(true);
+
+    //when then
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> paymentViewService.getPaymentRequest(rentalItemToken, rentalTime, paymentType))
+        .withMessage(ErrorCode.ALREADY_EXIST_ORDER_INFO.getMessage());
+
+    verify(rentalItemRepository, never()).findByToken(anyString());
+    verify(orderInfoService, never()).saveOrderInfo(anyString(), eq(rentalItemToken), eq(rentalTime), anyInt(), eq(paymentType));
+  }
+
+  @Test
+  @DisplayName("대여물품이 존재하지 않으면 예외 발생")
+  void notFoundRentalItem() {
+    //given
+    String rentalItemToken = "rentalItemToken";
+    Integer rentalTime = 1;
+    PaymentType paymentType = PaymentType.RENT;
+    given(orderInfoService.isExistOrderInfo(rentalItemToken)).willReturn(false);
+    given(rentalItemRepository.findByToken(rentalItemToken))
+        .willThrow(new BannabeServiceException(ErrorCode.RENTAL_ITEM_NOT_FOUND));
+
+    //when then
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> paymentViewService.getPaymentRequest(rentalItemToken, rentalTime, paymentType))
+        .withMessage(ErrorCode.RENTAL_ITEM_NOT_FOUND.getMessage());
+
+    verify(orderInfoService, never()).saveOrderInfo(anyString(), eq(rentalItemToken), eq(rentalTime), anyInt(), eq(paymentType));
+  }
+
+}

--- a/server/src/test/java/site/bannabe/server/domain/payments/service/TestRentalStockService.java
+++ b/server/src/test/java/site/bannabe/server/domain/payments/service/TestRentalStockService.java
@@ -10,11 +10,11 @@ import site.bannabe.server.domain.rentals.entity.RentalStations;
 import site.bannabe.server.domain.rentals.repository.RentalStationItemRepository;
 
 @Service
-public class RentalStockService {
+public class TestRentalStockService {
 
   private final RentalStationItemRepository rentalStationItemRepository;
 
-  public RentalStockService(RentalStationItemRepository rentalStationItemRepository) {
+  public TestRentalStockService(RentalStationItemRepository rentalStationItemRepository) {
     this.rentalStationItemRepository = rentalStationItemRepository;
   }
 

--- a/server/src/test/java/site/bannabe/server/domain/rentals/service/RentalStationServiceTest.java
+++ b/server/src/test/java/site/bannabe/server/domain/rentals/service/RentalStationServiceTest.java
@@ -1,0 +1,107 @@
+package site.bannabe.server.domain.rentals.service;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import site.bannabe.server.domain.rentals.entity.RentalStations;
+import site.bannabe.server.domain.rentals.repository.RentalStationRepository;
+import site.bannabe.server.domain.users.entity.BookmarkStations;
+import site.bannabe.server.domain.users.entity.Users;
+import site.bannabe.server.domain.users.repository.BookmarkStationRepository;
+import site.bannabe.server.domain.users.repository.UserRepository;
+import site.bannabe.server.global.exceptions.BannabeServiceException;
+import site.bannabe.server.global.exceptions.ErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class RentalStationServiceTest {
+
+  private final Long stationId = 1L;
+  private final String email = "test@test.com";
+  private final Users mockUser = mock(Users.class);
+  private final RentalStations mockStation = mock(RentalStations.class);
+
+  @InjectMocks
+  private RentalStationService rentalStationService;
+  @Mock
+  private RentalStationRepository rentalStationRepository;
+  @Mock
+  private UserRepository userRepository;
+  @Mock
+  private BookmarkStationRepository bookmarkStationRepository;
+
+  @Test
+  @DisplayName("북마크 추가 성공")
+  void bookmarkRentalStation() {
+    //given
+
+    given(userRepository.findByEmail(email)).willReturn(Optional.of(mockUser));
+    given(rentalStationRepository.findById(stationId)).willReturn(Optional.of(mockStation));
+    given(bookmarkStationRepository.existsByUserAndStation(mockUser, mockStation)).willReturn(false);
+
+    //when
+    rentalStationService.bookmarkRentalStation(stationId, email);
+
+    //then
+    verify(bookmarkStationRepository).save(any(BookmarkStations.class));
+  }
+
+  @Test
+  @DisplayName("회원 정보가 존재하지 않으면 예외 발생")
+  void notFoundUser() {
+    //given
+    given(userRepository.findByEmail(email)).willReturn(Optional.empty());
+
+    //when then
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> rentalStationService.bookmarkRentalStation(stationId, email))
+        .withMessage(ErrorCode.USER_NOT_FOUND.getMessage());
+
+    verify(rentalStationRepository, never()).findById(stationId);
+    verify(bookmarkStationRepository, never()).existsByEmailAndId(email, stationId);
+    verify(bookmarkStationRepository, never()).save(any(BookmarkStations.class));
+  }
+
+  @Test
+  @DisplayName("스테이션 정보가 존재하지 않으면 예외 발생")
+  void notFoundRentalStation() {
+    //given
+    given(userRepository.findByEmail(email)).willReturn(Optional.of(mockUser));
+    given(rentalStationRepository.findById(stationId)).willReturn(Optional.empty());
+
+    //when then
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> rentalStationService.bookmarkRentalStation(stationId, email))
+        .withMessage(ErrorCode.RENTAL_STATION_NOT_FOUND.getMessage());
+
+    verify(bookmarkStationRepository, never()).existsByEmailAndId(email, stationId);
+    verify(bookmarkStationRepository, never()).save(any(BookmarkStations.class));
+  }
+
+  @Test
+  @DisplayName("이미 북마크한 스테이션이면 예외 발생")
+  void alreadyBookmarked() {
+    //given
+    given(userRepository.findByEmail(email)).willReturn(Optional.of(mockUser));
+    given(rentalStationRepository.findById(stationId)).willReturn(Optional.of(mockStation));
+    given(bookmarkStationRepository.existsByUserAndStation(mockUser, mockStation)).willReturn(true);
+
+    //when
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> rentalStationService.bookmarkRentalStation(stationId, email))
+        .withMessage(ErrorCode.ALREADY_BOOKMARKED.getMessage());
+
+    verify(bookmarkStationRepository, never()).save(any(BookmarkStations.class));
+  }
+
+}

--- a/server/src/test/java/site/bannabe/server/domain/rentals/service/RentalStationServiceTest.java
+++ b/server/src/test/java/site/bannabe/server/domain/rentals/service/RentalStationServiceTest.java
@@ -45,7 +45,7 @@ class RentalStationServiceTest {
   void bookmarkRentalStation() {
     //given
 
-    given(userRepository.findByEmail(email)).willReturn(Optional.of(mockUser));
+    given(userRepository.findByEmail(email)).willReturn(mockUser);
     given(rentalStationRepository.findById(stationId)).willReturn(Optional.of(mockStation));
     given(bookmarkStationRepository.existsByUserAndStation(mockUser, mockStation)).willReturn(false);
 
@@ -57,26 +57,10 @@ class RentalStationServiceTest {
   }
 
   @Test
-  @DisplayName("회원 정보가 존재하지 않으면 예외 발생")
-  void notFoundUser() {
-    //given
-    given(userRepository.findByEmail(email)).willReturn(Optional.empty());
-
-    //when then
-    assertThatExceptionOfType(BannabeServiceException.class)
-        .isThrownBy(() -> rentalStationService.bookmarkRentalStation(stationId, email))
-        .withMessage(ErrorCode.USER_NOT_FOUND.getMessage());
-
-    verify(rentalStationRepository, never()).findById(stationId);
-    verify(bookmarkStationRepository, never()).existsByEmailAndId(email, stationId);
-    verify(bookmarkStationRepository, never()).save(any(BookmarkStations.class));
-  }
-
-  @Test
   @DisplayName("스테이션 정보가 존재하지 않으면 예외 발생")
   void notFoundRentalStation() {
     //given
-    given(userRepository.findByEmail(email)).willReturn(Optional.of(mockUser));
+    given(userRepository.findByEmail(email)).willReturn(mockUser);
     given(rentalStationRepository.findById(stationId)).willReturn(Optional.empty());
 
     //when then
@@ -92,7 +76,7 @@ class RentalStationServiceTest {
   @DisplayName("이미 북마크한 스테이션이면 예외 발생")
   void alreadyBookmarked() {
     //given
-    given(userRepository.findByEmail(email)).willReturn(Optional.of(mockUser));
+    given(userRepository.findByEmail(email)).willReturn(mockUser);
     given(rentalStationRepository.findById(stationId)).willReturn(Optional.of(mockStation));
     given(bookmarkStationRepository.existsByUserAndStation(mockUser, mockStation)).willReturn(true);
 

--- a/server/src/test/java/site/bannabe/server/domain/users/repository/BookmarkStationRepositoryTest.java
+++ b/server/src/test/java/site/bannabe/server/domain/users/repository/BookmarkStationRepositoryTest.java
@@ -33,14 +33,13 @@ class BookmarkStationRepositoryTest extends AbstractTestContainers {
   private EntityManager em;
 
   private Users user;
-  private List<RentalStations> rentalStations;
   private List<BookmarkStations> bookmarkStations;
 
   @BeforeEach
   void init() {
     user = Users.builder().email("test@test.com").providerType(ProviderType.LOCAL).role(Role.USER).build();
     em.persist(user);
-    rentalStations = IntStream.range(0, 10).mapToObj(i -> {
+    List<RentalStations> rentalStations = IntStream.range(0, 10).mapToObj(i -> {
       RentalStations station = RentalStations.builder()
                                              .name("station" + i)
                                              .status(StationStatus.OPEN)
@@ -90,8 +89,8 @@ class BookmarkStationRepositoryTest extends AbstractTestContainers {
     //given
     RentalStations rentalStation = setupNotExistRentalStation();
     //when
-    boolean isExist = bookmarkStationRepository.existsBookmarkByEmail(user.getEmail(), bookmarkStations.get(0).getId());
-    boolean isNotExist = bookmarkStationRepository.existsBookmarkByEmail(user.getEmail(), rentalStation.getId());
+    boolean isExist = bookmarkStationRepository.existsByEmailAndId(user.getEmail(), bookmarkStations.get(0).getId());
+    boolean isNotExist = bookmarkStationRepository.existsByEmailAndId(user.getEmail(), rentalStation.getId());
     //then
     assertThat(isExist).isTrue();
     assertThat(isNotExist).isFalse();
@@ -104,8 +103,8 @@ class BookmarkStationRepositoryTest extends AbstractTestContainers {
     //given
     RentalStations rentalStation = setupNotExistRentalStation();
     //when
-    boolean isExist = bookmarkStationRepository.existsBookmarkByEmailAndStation(user, rentalStations.get(0));
-    boolean isNotExist = bookmarkStationRepository.existsBookmarkByEmail(user.getEmail(), rentalStation.getId());
+    boolean isExist = bookmarkStationRepository.existsByUserAndStation(user, bookmarkStations.get(0).getRentalStation());
+    boolean isNotExist = bookmarkStationRepository.existsByUserAndStation(user, rentalStation);
 
     //then
     assertThat(isExist).isTrue();

--- a/server/src/test/java/site/bannabe/server/domain/users/repository/UserRepositoryTest.java
+++ b/server/src/test/java/site/bannabe/server/domain/users/repository/UserRepositoryTest.java
@@ -1,0 +1,55 @@
+package site.bannabe.server.domain.users.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import site.bannabe.server.config.AbstractTestContainers;
+import site.bannabe.server.config.CustomDataJpaTest;
+import site.bannabe.server.domain.users.entity.Users;
+import site.bannabe.server.global.exceptions.BannabeServiceException;
+import site.bannabe.server.global.exceptions.ErrorCode;
+
+@CustomDataJpaTest
+class UserRepositoryTest extends AbstractTestContainers {
+
+  private final String email = "test@test.com";
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @PersistenceContext
+  private EntityManager em;
+
+  @Test
+  @DisplayName("이메일 기반 회원 조회")
+  void findByEmail() {
+    //given
+    Users user = Users.builder().email(email).build();
+    em.persist(user);
+    em.flush();
+    em.clear();
+
+    //when
+    Users result = userRepository.findByEmail(email);
+
+    //then
+    assertThat(result).isNotNull()
+                      .extracting("email")
+                      .isEqualTo(email);
+  }
+
+  @Test
+  @DisplayName("회원정보 미 존재시 예외 발생")
+  void notFoundUser() {
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> userRepository.findByEmail(email))
+        .withMessage(ErrorCode.USER_NOT_FOUND.getMessage());
+  }
+
+
+}

--- a/server/src/test/java/site/bannabe/server/domain/users/service/AuthServiceTest.java
+++ b/server/src/test/java/site/bannabe/server/domain/users/service/AuthServiceTest.java
@@ -10,7 +10,6 @@ import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.verify;
 import static org.mockito.BDDMockito.willThrow;
 
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -221,7 +220,7 @@ class AuthServiceTest {
   void resetPassword() {
     //given
     given(authCodeService.findAuthCode(email)).willReturn(new AuthCode(authCode, true));
-    given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+    given(userRepository.findByEmail(email)).willReturn(user);
     given(passwordService.encodePassword(newPassword)).willReturn(encodedPassword);
 
     //when
@@ -301,7 +300,7 @@ class AuthServiceTest {
   void reusedPassword() {
     //given
     given(authCodeService.findAuthCode(email)).willReturn(new AuthCode(authCode, true));
-    given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+    given(userRepository.findByEmail(email)).willReturn(user);
     willThrow(new BannabeServiceException(ErrorCode.DUPLICATE_PASSWORD)).given(passwordService)
                                                                         .validateReusedPassword(newPassword, user.getPassword());
     //when then

--- a/server/src/test/java/site/bannabe/server/domain/users/service/AuthServiceTest.java
+++ b/server/src/test/java/site/bannabe/server/domain/users/service/AuthServiceTest.java
@@ -1,7 +1,7 @@
 package site.bannabe.server.domain.users.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -102,9 +102,9 @@ class AuthServiceTest {
     given(userRepository.existsByEmail(anyString())).willReturn(true);
 
     //when then
-    assertThatThrownBy(() -> authService.registerUser(registerRequest))
-        .isInstanceOf(BannabeServiceException.class)
-        .hasMessage(ErrorCode.DUPLICATE_EMAIL.getMessage());
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> authService.registerUser(registerRequest))
+        .withMessage(ErrorCode.DUPLICATE_EMAIL.getMessage());
 
     verify(passwordService, never()).encodePassword(anyString());
     verify(userRepository, never()).save(any(Users.class));
@@ -137,9 +137,9 @@ class AuthServiceTest {
     willThrow(new BannabeAuthenticationException(ErrorCode.INVALID_TOKEN)).given(jwtService).validateToken(anyString());
 
     //when then
-    assertThatThrownBy(() -> authService.refreshToken(refreshToken))
-        .isInstanceOf(BannabeAuthenticationException.class)
-        .hasMessage(ErrorCode.INVALID_TOKEN.getMessage());
+    assertThatExceptionOfType(BannabeAuthenticationException.class)
+        .isThrownBy(() -> authService.refreshToken(refreshToken))
+        .withMessage(ErrorCode.INVALID_TOKEN.getMessage());
 
     verify(jwtService, never()).refreshJWT(anyString());
   }
@@ -166,9 +166,9 @@ class AuthServiceTest {
     given(userRepository.existsByEmail(email)).willReturn(false);
 
     //when then
-    assertThatThrownBy(() -> authService.sendAuthCode(email))
-        .isInstanceOf(BannabeServiceException.class)
-        .hasMessage(ErrorCode.USER_NOT_FOUND.getMessage());
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> authService.sendAuthCode(email))
+        .withMessage(ErrorCode.USER_NOT_FOUND.getMessage());
 
     verify(authCodeService, never()).saveAuthCode(eq(email), anyString());
     verify(mailService, never()).sendAuthCodeMail(eq(email), anyString());
@@ -194,9 +194,9 @@ class AuthServiceTest {
     given(authCodeService.findAuthCode(email)).willReturn(new AuthCode(authCode, true));
 
     //when then
-    assertThatThrownBy(() -> authService.verifyAuthCode(email, authCode))
-        .isInstanceOf(BannabeServiceException.class)
-        .hasMessage(ErrorCode.AUTH_CODE_ALREADY_VERIFIED.getMessage());
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> authService.verifyAuthCode(email, authCode))
+        .withMessage(ErrorCode.AUTH_CODE_ALREADY_VERIFIED.getMessage());
 
     verify(authCodeService, never()).markAuthCodeAsVerified(email);
   }
@@ -208,9 +208,9 @@ class AuthServiceTest {
     given(authCodeService.findAuthCode(email)).willReturn(new AuthCode("wrongAuthCode", false));
 
     //when then
-    assertThatThrownBy(() -> authService.verifyAuthCode(email, authCode))
-        .isInstanceOf(BannabeServiceException.class)
-        .hasMessage(ErrorCode.AUTH_CODE_MISMATCH.getMessage());
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> authService.verifyAuthCode(email, authCode))
+        .withMessage(ErrorCode.AUTH_CODE_MISMATCH.getMessage());
 
     verify(authCodeService, never()).markAuthCodeAsVerified(email);
   }
@@ -245,9 +245,9 @@ class AuthServiceTest {
     given(authCodeService.findAuthCode(email)).willReturn(new AuthCode(authCode, false));
 
     //when then
-    assertThatThrownBy(() -> authService.resetPassword(request))
-        .isInstanceOf(BannabeServiceException.class)
-        .hasMessage(ErrorCode.AUTH_CODE_NOT_VERIFIED.getMessage());
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> authService.resetPassword(request))
+        .withMessage(ErrorCode.AUTH_CODE_NOT_VERIFIED.getMessage());
 
     verify(authCodeService).findAuthCode(email);
     verify(passwordService, never()).validateNewPassword(newPassword, newPasswordConfirm);
@@ -264,9 +264,9 @@ class AuthServiceTest {
     given(authCodeService.findAuthCode(email)).willReturn(new AuthCode("wrongAuthCode", true));
 
     //when then
-    assertThatThrownBy(() -> authService.resetPassword(request))
-        .isInstanceOf(BannabeServiceException.class)
-        .hasMessage(ErrorCode.AUTH_CODE_MISMATCH.getMessage());
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> authService.resetPassword(request))
+        .withMessage(ErrorCode.AUTH_CODE_MISMATCH.getMessage());
 
     verify(authCodeService).findAuthCode(email);
     verify(passwordService, never()).validateNewPassword(newPassword, newPasswordConfirm);
@@ -284,9 +284,9 @@ class AuthServiceTest {
     willThrow(new BannabeServiceException(ErrorCode.NEW_PASSWORD_MISMATCH)).given(passwordService)
                                                                            .validateNewPassword(newPassword, newPasswordConfirm);
     //when then
-    assertThatThrownBy(() -> authService.resetPassword(request))
-        .isInstanceOf(BannabeServiceException.class)
-        .hasMessage(ErrorCode.NEW_PASSWORD_MISMATCH.getMessage());
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> authService.resetPassword(request))
+        .withMessage(ErrorCode.NEW_PASSWORD_MISMATCH.getMessage());
 
     verify(authCodeService).findAuthCode(email);
     verify(passwordService).validateNewPassword(newPassword, newPasswordConfirm);
@@ -305,9 +305,9 @@ class AuthServiceTest {
     willThrow(new BannabeServiceException(ErrorCode.DUPLICATE_PASSWORD)).given(passwordService)
                                                                         .validateReusedPassword(newPassword, user.getPassword());
     //when then
-    assertThatThrownBy(() -> authService.resetPassword(request))
-        .isInstanceOf(BannabeServiceException.class)
-        .hasMessage(ErrorCode.DUPLICATE_PASSWORD.getMessage());
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> authService.resetPassword(request))
+        .withMessage(ErrorCode.DUPLICATE_PASSWORD.getMessage());
 
     verify(authCodeService).findAuthCode(email);
     verify(passwordService).validateNewPassword(newPassword, newPasswordConfirm);

--- a/server/src/test/java/site/bannabe/server/domain/users/service/AuthServiceTest.java
+++ b/server/src/test/java/site/bannabe/server/domain/users/service/AuthServiceTest.java
@@ -1,0 +1,320 @@
+package site.bannabe.server.domain.users.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.BDDMockito.willThrow;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import site.bannabe.server.domain.users.controller.request.AuthResetPasswordRequest;
+import site.bannabe.server.domain.users.controller.request.UserRegisterRequest;
+import site.bannabe.server.domain.users.entity.Users;
+import site.bannabe.server.domain.users.repository.UserRepository;
+import site.bannabe.server.global.exceptions.BannabeAuthenticationException;
+import site.bannabe.server.global.exceptions.BannabeServiceException;
+import site.bannabe.server.global.exceptions.ErrorCode;
+import site.bannabe.server.global.jwt.GenerateToken;
+import site.bannabe.server.global.jwt.JwtService;
+import site.bannabe.server.global.mail.MailService;
+import site.bannabe.server.global.type.AuthCode;
+import site.bannabe.server.global.type.RefreshToken;
+import site.bannabe.server.global.type.TokenResponse;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private JwtService jwtService;
+
+  @Mock
+  private MailService mailService;
+
+  @Mock
+  private AuthCodeService authCodeService;
+
+  @Mock
+  private PasswordService passwordService;
+
+  @InjectMocks
+  private AuthService authService;
+
+  private String email;
+  private String authCode;
+  private String newPassword;
+  private String newPasswordConfirm;
+  private String password;
+  private String encodedPassword;
+  private String refreshToken;
+  private Users user;
+  private AuthResetPasswordRequest request;
+
+  @BeforeEach
+  void setUp() {
+    email = "test@test.com";
+    authCode = "authCode";
+    newPassword = "newPassword";
+    newPasswordConfirm = "newPassword";
+    password = "1234567890";
+    encodedPassword = "encodedPassword";
+    user = Users.builder().email(email).password(password).build();
+    request = new AuthResetPasswordRequest(authCode, email, newPassword, newPasswordConfirm);
+    refreshToken = "refreshToken";
+  }
+
+  @Test
+  @DisplayName("회원가입 성공")
+  void registerUser() {
+    //given
+    UserRegisterRequest registerRequest = new UserRegisterRequest(email, password);
+    given(userRepository.existsByEmail(anyString())).willReturn(false);
+    given(passwordService.encodePassword(anyString())).willReturn(encodedPassword);
+    given(userRepository.save(any(Users.class))).willReturn(Users.builder().build());
+
+    //when
+    authService.registerUser(registerRequest);
+
+    //then
+    verify(userRepository).save(any(Users.class));
+    verify(passwordService).encodePassword(anyString());
+    verify(userRepository).save(any(Users.class));
+  }
+
+  @Test
+  @DisplayName("이메일 중복시 예외 발생")
+  void registerUserDuplicateEmail() {
+    //given
+    UserRegisterRequest registerRequest = new UserRegisterRequest(email, password);
+    given(userRepository.existsByEmail(anyString())).willReturn(true);
+
+    //when then
+    assertThatThrownBy(() -> authService.registerUser(registerRequest))
+        .isInstanceOf(BannabeServiceException.class)
+        .hasMessage(ErrorCode.DUPLICATE_EMAIL.getMessage());
+
+    verify(passwordService, never()).encodePassword(anyString());
+    verify(userRepository, never()).save(any(Users.class));
+  }
+
+  @Test
+  @DisplayName("JWT 갱신 성공")
+  void refreshToken() {
+    //given
+    String newAccessToken = "newAccessToken";
+    String newRefreshToken = "newRefreshToken";
+    RefreshToken refreshTokenEntity = new RefreshToken("test@test.com", newRefreshToken);
+    given(jwtService.refreshJWT(refreshToken)).willReturn(new GenerateToken(newAccessToken, refreshTokenEntity));
+
+    //when
+    TokenResponse tokenResponse = authService.refreshToken(refreshToken);
+
+    //then
+    assertThat(tokenResponse).isNotNull()
+                             .extracting(TokenResponse::accessToken, TokenResponse::refreshToken)
+                             .containsExactly(newAccessToken, newRefreshToken);
+
+    verify(jwtService).validateToken(refreshToken);
+  }
+
+  @Test
+  @DisplayName("토큰 검증 실패시 예외 발생")
+  void validateTokenTest() {
+    //given
+    willThrow(new BannabeAuthenticationException(ErrorCode.INVALID_TOKEN)).given(jwtService).validateToken(anyString());
+
+    //when then
+    assertThatThrownBy(() -> authService.refreshToken(refreshToken))
+        .isInstanceOf(BannabeAuthenticationException.class)
+        .hasMessage(ErrorCode.INVALID_TOKEN.getMessage());
+
+    verify(jwtService, never()).refreshJWT(anyString());
+  }
+
+  @Test
+  @DisplayName("인증코드 전송")
+  void sendAuthCode() {
+    //given
+    given(userRepository.existsByEmail(email)).willReturn(true);
+
+    //when
+    authService.sendAuthCode(email);
+
+    //then
+    verify(userRepository).existsByEmail(email);
+    verify(authCodeService).saveAuthCode(eq(email), anyString());
+    verify(mailService).sendAuthCodeMail(eq(email), anyString());
+  }
+
+  @Test
+  @DisplayName("메일이 존재하지 않을 시 예외 발생")
+  void sendAuthCodeDuplicateEmail() {
+    //given
+    given(userRepository.existsByEmail(email)).willReturn(false);
+
+    //when then
+    assertThatThrownBy(() -> authService.sendAuthCode(email))
+        .isInstanceOf(BannabeServiceException.class)
+        .hasMessage(ErrorCode.USER_NOT_FOUND.getMessage());
+
+    verify(authCodeService, never()).saveAuthCode(eq(email), anyString());
+    verify(mailService, never()).sendAuthCodeMail(eq(email), anyString());
+  }
+
+  @Test
+  @DisplayName("인증코드 검증 성공")
+  void verifyAuthCode() {
+    //given
+    given(authCodeService.findAuthCode(email)).willReturn(new AuthCode(authCode, false));
+
+    //when
+    authService.verifyAuthCode(email, authCode);
+
+    //then
+    verify(authCodeService).markAuthCodeAsVerified(email);
+  }
+
+  @Test
+  @DisplayName("이미 인증된 코드라면 예외 발생")
+  void alreadyVerifiedAuthCode() {
+    //given
+    given(authCodeService.findAuthCode(email)).willReturn(new AuthCode(authCode, true));
+
+    //when then
+    assertThatThrownBy(() -> authService.verifyAuthCode(email, authCode))
+        .isInstanceOf(BannabeServiceException.class)
+        .hasMessage(ErrorCode.AUTH_CODE_ALREADY_VERIFIED.getMessage());
+
+    verify(authCodeService, never()).markAuthCodeAsVerified(email);
+  }
+
+  @Test
+  @DisplayName("인증코드 검증 시 인증코드 불일치시 예외 발생")
+  void mismatchAuthCode() {
+    //given
+    given(authCodeService.findAuthCode(email)).willReturn(new AuthCode("wrongAuthCode", false));
+
+    //when then
+    assertThatThrownBy(() -> authService.verifyAuthCode(email, authCode))
+        .isInstanceOf(BannabeServiceException.class)
+        .hasMessage(ErrorCode.AUTH_CODE_MISMATCH.getMessage());
+
+    verify(authCodeService, never()).markAuthCodeAsVerified(email);
+  }
+
+  // 비밀번호 재설정 테스트
+  @Test
+  @DisplayName("비밀번호 재설정 성공")
+  void resetPassword() {
+    //given
+    given(authCodeService.findAuthCode(email)).willReturn(new AuthCode(authCode, true));
+    given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+    given(passwordService.encodePassword(newPassword)).willReturn(encodedPassword);
+
+    //when
+    authService.resetPassword(request);
+
+    //then
+    assertThat(user.getPassword()).isEqualTo(encodedPassword);
+
+    verify(authCodeService).findAuthCode(email);
+    verify(passwordService).validateNewPassword(anyString(), anyString());
+    verify(userRepository).findByEmail(email);
+    verify(passwordService).validateReusedPassword(newPassword, password);
+    verify(passwordService).encodePassword(newPassword);
+    verify(authCodeService).removeAuthCode(email);
+  }
+
+  @Test
+  @DisplayName("미검증 인증코드 예외 발생")
+  void resetPasswordNotVerifiedAuthCode() {
+    //given
+    given(authCodeService.findAuthCode(email)).willReturn(new AuthCode(authCode, false));
+
+    //when then
+    assertThatThrownBy(() -> authService.resetPassword(request))
+        .isInstanceOf(BannabeServiceException.class)
+        .hasMessage(ErrorCode.AUTH_CODE_NOT_VERIFIED.getMessage());
+
+    verify(authCodeService).findAuthCode(email);
+    verify(passwordService, never()).validateNewPassword(newPassword, newPasswordConfirm);
+    verify(userRepository, never()).findByEmail(email);
+    verify(passwordService, never()).validateReusedPassword(eq(newPassword), anyString());
+    verify(passwordService, never()).encodePassword(newPassword);
+    verify(authCodeService, never()).removeAuthCode(email);
+  }
+
+  @Test
+  @DisplayName("비밀번호 재설정 중 인증코드 불일치 시 예외 발생")
+  void resetPasswordMismatchAuthCode() {
+    //given
+    given(authCodeService.findAuthCode(email)).willReturn(new AuthCode("wrongAuthCode", true));
+
+    //when then
+    assertThatThrownBy(() -> authService.resetPassword(request))
+        .isInstanceOf(BannabeServiceException.class)
+        .hasMessage(ErrorCode.AUTH_CODE_MISMATCH.getMessage());
+
+    verify(authCodeService).findAuthCode(email);
+    verify(passwordService, never()).validateNewPassword(newPassword, newPasswordConfirm);
+    verify(userRepository, never()).findByEmail(email);
+    verify(passwordService, never()).validateReusedPassword(eq(newPassword), anyString());
+    verify(passwordService, never()).encodePassword(newPassword);
+    verify(authCodeService, never()).removeAuthCode(email);
+  }
+
+  @Test
+  @DisplayName("새 비밀번호 불일치 시 예외 발생")
+  void resetPasswordValidateNewPassword() {
+    //given
+    given(authCodeService.findAuthCode(email)).willReturn(new AuthCode(authCode, true));
+    willThrow(new BannabeServiceException(ErrorCode.NEW_PASSWORD_MISMATCH)).given(passwordService)
+                                                                           .validateNewPassword(newPassword, newPasswordConfirm);
+    //when then
+    assertThatThrownBy(() -> authService.resetPassword(request))
+        .isInstanceOf(BannabeServiceException.class)
+        .hasMessage(ErrorCode.NEW_PASSWORD_MISMATCH.getMessage());
+
+    verify(authCodeService).findAuthCode(email);
+    verify(passwordService).validateNewPassword(newPassword, newPasswordConfirm);
+    verify(userRepository, never()).findByEmail(email);
+    verify(passwordService, never()).validateReusedPassword(eq(newPassword), anyString());
+    verify(passwordService, never()).encodePassword(newPassword);
+    verify(authCodeService, never()).removeAuthCode(email);
+  }
+
+  @Test
+  @DisplayName("비밀번호 재사용 시 예외 발생")
+  void reusedPassword() {
+    //given
+    given(authCodeService.findAuthCode(email)).willReturn(new AuthCode(authCode, true));
+    given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+    willThrow(new BannabeServiceException(ErrorCode.DUPLICATE_PASSWORD)).given(passwordService)
+                                                                        .validateReusedPassword(newPassword, user.getPassword());
+    //when then
+    assertThatThrownBy(() -> authService.resetPassword(request))
+        .isInstanceOf(BannabeServiceException.class)
+        .hasMessage(ErrorCode.DUPLICATE_PASSWORD.getMessage());
+
+    verify(authCodeService).findAuthCode(email);
+    verify(passwordService).validateNewPassword(newPassword, newPasswordConfirm);
+    verify(userRepository).findByEmail(email);
+    verify(passwordService).validateReusedPassword(eq(newPassword), anyString());
+    verify(passwordService, never()).encodePassword(newPassword);
+    verify(authCodeService, never()).removeAuthCode(email);
+  }
+
+}

--- a/server/src/test/java/site/bannabe/server/domain/users/service/PasswordServiceTest.java
+++ b/server/src/test/java/site/bannabe/server/domain/users/service/PasswordServiceTest.java
@@ -1,0 +1,93 @@
+package site.bannabe.server.domain.users.service;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import site.bannabe.server.global.exceptions.BannabeServiceException;
+import site.bannabe.server.global.exceptions.ErrorCode;
+
+class PasswordServiceTest {
+
+  private final BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+  private final PasswordService passwordService = new PasswordService(encoder);
+
+  @Test
+  @DisplayName("새 비밀번호 검증 성공")
+  void validateNewPassword() {
+    //given
+    String newPassword = "newPassword";
+    String newPasswordConfirm = "newPassword";
+
+    //when
+    passwordService.validateNewPassword(newPassword, newPasswordConfirm);
+
+    //then
+    assertThatNoException().isThrownBy(() -> passwordService.validateNewPassword(newPassword, newPasswordConfirm));
+  }
+
+  @Test
+  @DisplayName("새 비밀번호 불일치 시 예외 발생")
+  void mismatchNewPassword() {
+    //given
+    String newPassword = "newPassword";
+    String newPasswordConfirm = "wrongPassword";
+
+    //when then
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> passwordService.validateNewPassword(newPassword, newPasswordConfirm))
+        .withMessage(ErrorCode.NEW_PASSWORD_MISMATCH.getMessage());
+  }
+
+  @Test
+  @DisplayName("비밀번호 재사용 검증 성공")
+  void validateReusedPassword() {
+    //given
+    String newPassword = "newPassword";
+    String currentPassword = encoder.encode("currentPassword");
+
+    //when then
+    assertThatNoException().isThrownBy(() -> passwordService.validateReusedPassword(newPassword, currentPassword));
+  }
+
+  @Test
+  @DisplayName("비밀번호 재사용시 예외 발생")
+  void reusedPassword() {
+    //given
+    String newPassword = "currentPassword";
+    String currentPassword = encoder.encode("currentPassword");
+
+    //when then
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> passwordService.validateReusedPassword(newPassword, currentPassword))
+        .withMessage(ErrorCode.DUPLICATE_PASSWORD.getMessage());
+  }
+
+  @Test
+  @DisplayName("기존 비밀번호 일치 검증")
+  void validateCurrentPassword() {
+    //given
+    String currentPassword = "currentPassword";
+    String encodedPassword = encoder.encode(currentPassword);
+
+    //when then
+    assertThatNoException().isThrownBy(() -> passwordService.validateCurrentPassword(currentPassword, encodedPassword));
+  }
+
+
+  @Test
+  @DisplayName("기존 비밀번호 불일치시 예외 발생")
+  void mismatchCurrentPassword() {
+    //given
+    String currentPassword = "currentPassword";
+    String encodedPassword = encoder.encode("wrongPassword");
+
+    //when then
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> passwordService.validateCurrentPassword(currentPassword, encodedPassword))
+        .withMessage(ErrorCode.PASSWORD_MISMATCH.getMessage());
+  }
+
+}

--- a/server/src/test/java/site/bannabe/server/domain/users/service/UserServiceTest.java
+++ b/server/src/test/java/site/bannabe/server/domain/users/service/UserServiceTest.java
@@ -395,7 +395,7 @@ class UserServiceTest {
     //given
     Long bookmarkId = 1L;
 
-    given(bookmarkStationRepository.existsBookmarkByEmail(EMAIL, bookmarkId)).willReturn(Boolean.TRUE);
+    given(bookmarkStationRepository.existsByEmailAndId(EMAIL, bookmarkId)).willReturn(Boolean.TRUE);
 
     //when
     userService.removeBookmarkStation(EMAIL, bookmarkId);
@@ -410,7 +410,7 @@ class UserServiceTest {
     //given
     Long bookmarkId = 1L;
 
-    given(bookmarkStationRepository.existsBookmarkByEmail(EMAIL, bookmarkId)).willReturn(Boolean.FALSE);
+    given(bookmarkStationRepository.existsByEmailAndId(EMAIL, bookmarkId)).willReturn(Boolean.FALSE);
 
     //when then
     assertThatExceptionOfType(BannabeServiceException.class)

--- a/server/src/test/java/site/bannabe/server/domain/users/service/UserServiceTest.java
+++ b/server/src/test/java/site/bannabe/server/domain/users/service/UserServiceTest.java
@@ -1,0 +1,421 @@
+package site.bannabe.server.domain.users.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+import site.bannabe.server.domain.rentals.entity.RentalHistory;
+import site.bannabe.server.domain.rentals.entity.RentalItemTypes;
+import site.bannabe.server.domain.rentals.entity.RentalItems;
+import site.bannabe.server.domain.rentals.entity.RentalStations;
+import site.bannabe.server.domain.rentals.entity.RentalStatus;
+import site.bannabe.server.domain.rentals.repository.RentalHistoryRepository;
+import site.bannabe.server.domain.users.controller.request.UserChangeNicknameRequest;
+import site.bannabe.server.domain.users.controller.request.UserChangePasswordRequest;
+import site.bannabe.server.domain.users.controller.request.UserChangeProfileImageRequest;
+import site.bannabe.server.domain.users.controller.response.UserBookmarkStationsResponse;
+import site.bannabe.server.domain.users.controller.response.UserBookmarkStationsResponse.BookmarkStationResponse;
+import site.bannabe.server.domain.users.controller.response.UserGetActiveRentalResponse.RentalHistoryResponse;
+import site.bannabe.server.domain.users.entity.Users;
+import site.bannabe.server.domain.users.repository.BookmarkStationRepository;
+import site.bannabe.server.domain.users.repository.UserRepository;
+import site.bannabe.server.global.aws.S3Service;
+import site.bannabe.server.global.exceptions.BannabeServiceException;
+import site.bannabe.server.global.exceptions.ErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+  private static final String EMAIL = "test@test.com";
+  @Mock
+  private UserRepository userRepository;
+  @Mock
+  private RentalHistoryRepository rentalHistoryRepository;
+  @Mock
+  private BookmarkStationRepository bookmarkStationRepository;
+  @Mock
+  private S3Service s3Service;
+  @Mock
+  private PasswordService passwordService;
+  @InjectMocks
+  private UserService userService;
+
+  @BeforeEach
+  void setUp() {
+    ReflectionTestUtils.setField(userService, "defaultProfileImage", "defaultProfileImage.png");
+  }
+
+  @Test
+  @DisplayName("비밀번호 변경 성공")
+  void changePassword() {
+    //given
+    String currentPassword = "currentPassword";
+    String currentEncodedPassword = "currentEncodedPassword";
+    String newPassword = "newPassword";
+    String newPasswordConfirm = "newPassword";
+    String encodedPassword = "encodedPassword";
+    UserChangePasswordRequest request = new UserChangePasswordRequest(currentPassword, newPassword, newPasswordConfirm);
+    Users user = Users.builder().email(EMAIL).password(currentEncodedPassword).build();
+
+    given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(user));
+    given(passwordService.encodePassword(newPassword)).willReturn(encodedPassword);
+
+    //when
+    userService.changePassword(EMAIL, request);
+
+    //then
+    assertThat(user.getPassword()).isEqualTo(encodedPassword);
+    verify(passwordService).validateNewPassword(newPassword, newPasswordConfirm);
+    verify(passwordService).validateCurrentPassword(currentPassword, currentEncodedPassword);
+    verify(passwordService).validateReusedPassword(newPassword, currentEncodedPassword);
+  }
+
+  @Test
+  @DisplayName("비밀번호 변경 중 새 비밀번호 불일치 시 예외 발생")
+  void invalidNewPassword() {
+    //given
+    String currentPassword = "currentPassword";
+    String newPassword = "newPassword";
+    String newPasswordConfirm = "newPasswordConfirm";
+    UserChangePasswordRequest request = new UserChangePasswordRequest(currentPassword, newPassword, newPasswordConfirm);
+    willThrow(new BannabeServiceException(ErrorCode.NEW_PASSWORD_MISMATCH)).given(passwordService)
+                                                                           .validateNewPassword(newPassword, newPasswordConfirm);
+
+    //when then
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> userService.changePassword(EMAIL, request))
+        .withMessage(ErrorCode.NEW_PASSWORD_MISMATCH.getMessage());
+
+    verify(passwordService, never()).validateCurrentPassword(eq(currentPassword), anyString());
+    verify(passwordService, never()).validateReusedPassword(eq(newPassword), anyString());
+    verify(passwordService, never()).encodePassword(newPassword);
+  }
+
+  @Test
+  @DisplayName("비밀번호 변경 중 회원정보가 없을 시 예외 발생")
+  void changePasswordNotFoundUser() {
+    //given
+    String currentPassword = "currentPassword";
+    String newPassword = "newPassword";
+    String newPasswordConfirm = "newPasswordConfirm";
+    UserChangePasswordRequest request = new UserChangePasswordRequest(currentPassword, newPassword, newPasswordConfirm);
+
+    given(userRepository.findByEmail(EMAIL)).willReturn(Optional.empty());
+
+    //when then
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> userService.changePassword(EMAIL, request))
+        .withMessage(ErrorCode.USER_NOT_FOUND.getMessage());
+
+    verify(passwordService).validateNewPassword(newPassword, newPasswordConfirm);
+    verify(passwordService, never()).validateCurrentPassword(eq(currentPassword), anyString());
+    verify(passwordService, never()).validateReusedPassword(eq(newPassword), anyString());
+    verify(passwordService, never()).encodePassword(newPassword);
+  }
+
+  @Test
+  @DisplayName("비밀번호 변경 중 현재 비밀번호 불일치 시 예외 발생")
+  void changePasswordInvalidCurrentPassword() {
+    //given
+    String currentPassword = "currentPassword";
+    String currentEncodedPassword = "currentEncodedPassword";
+    String newPassword = "newPassword";
+    String newPasswordConfirm = "newPasswordConfirm";
+    UserChangePasswordRequest request = new UserChangePasswordRequest(currentPassword, newPassword, newPasswordConfirm);
+    Users user = Users.builder().email(EMAIL).password(currentEncodedPassword).build();
+
+    given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(user));
+    willThrow(new BannabeServiceException(ErrorCode.PASSWORD_MISMATCH)).given(passwordService)
+                                                                       .validateCurrentPassword(currentPassword,
+                                                                           user.getPassword());
+    //when then
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> userService.changePassword(EMAIL, request))
+        .withMessage(ErrorCode.PASSWORD_MISMATCH.getMessage());
+
+    verify(passwordService).validateNewPassword(newPassword, newPasswordConfirm);
+    verify(passwordService).validateCurrentPassword(eq(currentPassword), anyString());
+    verify(passwordService, never()).validateReusedPassword(eq(newPassword), anyString());
+    verify(passwordService, never()).encodePassword(newPassword);
+  }
+
+  @Test
+  @DisplayName("비밀번호 변경 중 새 비밀번호가 현재 비밀번호와 일치할 시 예외 발생")
+  void changePasswordReusedPassword() {
+    //given
+    String currentPassword = "currentPassword";
+    String currentEncodedPassword = "currentEncodedPassword";
+    String newPassword = "newPassword";
+    String newPasswordConfirm = "newPasswordConfirm";
+    UserChangePasswordRequest request = new UserChangePasswordRequest(currentPassword, newPassword, newPasswordConfirm);
+    Users user = Users.builder().email(EMAIL).password(currentEncodedPassword).build();
+
+    given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(user));
+    willThrow(new BannabeServiceException(ErrorCode.DUPLICATE_PASSWORD)).given(passwordService)
+                                                                        .validateReusedPassword(newPassword,
+                                                                            currentEncodedPassword);
+    //when then
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> userService.changePassword(EMAIL, request))
+        .withMessage(ErrorCode.DUPLICATE_PASSWORD.getMessage());
+
+    verify(passwordService).validateNewPassword(newPassword, newPasswordConfirm);
+    verify(passwordService).validateCurrentPassword(eq(currentPassword), anyString());
+    verify(passwordService).validateReusedPassword(eq(newPassword), eq(currentEncodedPassword));
+    verify(passwordService, never()).encodePassword(newPassword);
+  }
+
+  @Test
+  @DisplayName("닉네임 변경 성공")
+  void changeNickname() {
+    //given
+    String newNickname = "nickname";
+    String currentNickname = "currentNickname";
+    Users user = Users.builder().email(EMAIL).nickname(currentNickname).build();
+
+    given(userRepository.existsByNickname(newNickname)).willReturn(Boolean.FALSE);
+    given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(user));
+
+    //when
+    userService.changeNickname(EMAIL, new UserChangeNicknameRequest(newNickname));
+
+    //then
+    assertThat(user.getNickname()).isEqualTo(newNickname);
+
+    verify(userRepository).existsByNickname(newNickname);
+    verify(userRepository).findByEmail(EMAIL);
+  }
+
+  @Test
+  @DisplayName("닉네임 중복시 예외 발생")
+  void duplicateNickname() {
+    //given
+    String newNickname = "nickname";
+
+    given(userRepository.existsByNickname(newNickname)).willReturn(Boolean.TRUE);
+
+    //when then
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> userService.changeNickname(EMAIL, new UserChangeNicknameRequest(newNickname)))
+        .withMessage(ErrorCode.DUPLICATE_NICKNAME.getMessage());
+
+    verify(userRepository, never()).findByEmail(EMAIL);
+  }
+
+  @Test
+  @DisplayName("닉네임 변경 중 회원정보가 없을 시 예외 발생")
+  void notFoundUserChangeNickname() {
+    //given
+    String newNickname = "nickname";
+
+    given(userRepository.existsByNickname(newNickname)).willReturn(Boolean.FALSE);
+    given(userRepository.findByEmail(EMAIL)).willReturn(Optional.empty());
+
+    //when then
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> userService.changeNickname(EMAIL, new UserChangeNicknameRequest(newNickname)))
+        .withMessage(ErrorCode.USER_NOT_FOUND.getMessage());
+  }
+
+  @Test
+  @DisplayName("프로필 이미지 변경 성공 테스트")
+  void changeProfileImage() {
+    //given
+    String newImageUrl = "newImageUrl";
+    String currentProfileImage = "currentProfileImage";
+    Users user = Users.builder().email(EMAIL).profileImage(currentProfileImage).build();
+    given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(user));
+
+    //when
+    userService.changeProfileImage(EMAIL, new UserChangeProfileImageRequest(newImageUrl));
+
+    //then
+    assertThat(user.getProfileImage()).isEqualTo(newImageUrl);
+    verify(s3Service).removeProfileImage(currentProfileImage);
+  }
+
+  @Test
+  @DisplayName("프로필 이미지 변경 중 회원정보가 없을 시 예외 발생")
+  void notFoundUserChangeProfileImage() {
+    //given
+    String newImageUrl = "newImageUrl";
+
+    given(userRepository.findByEmail(EMAIL)).willReturn(Optional.empty());
+
+    //when
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> userService.changeProfileImage(EMAIL, new UserChangeProfileImageRequest(newImageUrl)))
+        .withMessage(ErrorCode.USER_NOT_FOUND.getMessage());
+    verify(s3Service, never()).removeProfileImage(anyString());
+  }
+
+  @Test
+  @DisplayName("대여현황 중 expectedReturnTime이 현재 시간보다 이전이면 Overdue로 상태 변경")
+  void validateOverdueFromActiveRentalHistory() {
+    //given
+    int rentalTimeHour = 1;
+    LocalDateTime startTime = LocalDateTime.now().minusDays(1);
+    String token = "token";
+
+    RentalItemTypes rentalItemType = RentalItemTypes.builder().name("충전기").build();
+    RentalItems rentalItem = RentalItems.builder().rentalItemType(rentalItemType).build();
+    RentalHistory rentalHistory = RentalHistory.builder().rentalItem(rentalItem)
+                                               .rentalTimeHour(rentalTimeHour)
+                                               .startTime(startTime)
+                                               .expectedReturnTime(startTime.plusHours(rentalTimeHour))
+                                               .token(token)
+                                               .status(RentalStatus.RENTAL)
+                                               .build();
+    List<RentalHistory> rentalHistories = List.of(rentalHistory);
+    given(rentalHistoryRepository.findActiveRentalsBy(EMAIL)).willReturn(rentalHistories);
+
+    //when
+    List<RentalHistoryResponse> result = userService.getActiveRentalHistory(EMAIL);
+
+    //then
+    assertThat(result).isNotEmpty();
+    assertThat(result.get(0)).isNotNull()
+                             .extracting(RentalHistoryResponse::status)
+                             .isEqualTo(RentalStatus.OVERDUE.getDescription());
+  }
+
+  @Test
+  @DisplayName("현재 대여중인 내역이 없다면 빈 List 반환")
+  void isEmptyActiveRentalHistory() {
+    //given
+    given(rentalHistoryRepository.findActiveRentalsBy(EMAIL)).willReturn(List.of());
+
+    //when
+    List<RentalHistoryResponse> result = userService.getActiveRentalHistory(EMAIL);
+
+    //then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("대여내역 중 expectedReturnTime이 현재 시간보다 이전이면 Overdue로 상태 변경")
+  void validateOverdueFromAllRentalHistory() {
+    //given
+    PageRequest pageRequest = PageRequest.of(0, 10);
+    int rentalTimeHour = 1;
+    LocalDateTime startTime = LocalDateTime.now().minusHours(1);
+    RentalHistory rentalHistory = RentalHistory.builder()
+                                               .status(RentalStatus.RENTAL)
+                                               .rentalItem(
+                                                   RentalItems.builder().rentalItemType(
+                                                       RentalItemTypes.builder().name("충전기").build()).build()
+                                               )
+                                               .rentalTimeHour(rentalTimeHour)
+                                               .startTime(startTime)
+                                               .expectedReturnTime(startTime.plusHours(rentalTimeHour))
+                                               .token("token")
+                                               .build();
+    List<RentalHistory> rentalHistories = List.of(rentalHistory);
+    PageImpl<RentalHistory> rentalHistoryPage = new PageImpl<>(rentalHistories);
+    given(rentalHistoryRepository.findAllRentalsBy(EMAIL, pageRequest)).willReturn(rentalHistoryPage);
+
+    //when
+    Page<RentalHistoryResponse> result = userService.getRentalHistory(EMAIL, pageRequest);
+
+    //then
+    assertThat(result).isNotEmpty();
+    assertThat(result.getContent().get(0)).isNotNull()
+                                          .extracting(RentalHistoryResponse::status)
+                                          .isEqualTo(RentalStatus.OVERDUE.getDescription());
+  }
+
+  @Test
+  @DisplayName("대여내역 미 존재시 빈 리스트 반환")
+  void isEmptyRentalHistory() {
+    //given
+    PageRequest pageRequest = PageRequest.of(0, 10);
+    given(rentalHistoryRepository.findAllRentalsBy(EMAIL, pageRequest)).willReturn(new PageImpl<>(List.of()));
+
+    //when
+    Page<RentalHistoryResponse> result = userService.getRentalHistory(EMAIL, pageRequest);
+
+    //then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("북마크 스테이션 조회")
+  void getBookmarkStations() {
+    //given
+    List<RentalStations> stations = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      stations.add(RentalStations.builder().name("station" + i).build());
+    }
+
+    List<BookmarkStationResponse> bookmarks = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      bookmarks.add(new BookmarkStationResponse(stations.get(i).getName(), (long) i, (long) i));
+    }
+
+    given(bookmarkStationRepository.findBookmarkStationsBy(any())).willReturn(bookmarks);
+
+    //when
+    UserBookmarkStationsResponse result = userService.getBookmarkStations("test@test.com");
+
+    //then
+    assertThat(result).isNotNull();
+    assertThat(result.bookmarks()).isNotEmpty().hasSize(bookmarks.size());
+    for (int i = 0; i < 10; i++) {
+      BookmarkStationResponse response = bookmarks.get(i);
+      assertThat(response).isNotNull()
+                          .extracting(BookmarkStationResponse::name)
+                          .isEqualTo(stations.get(i).getName());
+    }
+  }
+
+  @Test
+  @DisplayName("북마크 스테이션 존재 시 북마크 삭제 메서드 호출")
+  void removeBookmarkStation() {
+    //given
+    Long bookmarkId = 1L;
+
+    given(bookmarkStationRepository.existsBookmarkByEmail(EMAIL, bookmarkId)).willReturn(Boolean.TRUE);
+
+    //when
+    userService.removeBookmarkStation(EMAIL, bookmarkId);
+
+    //then
+    verify(bookmarkStationRepository).deleteBookmarkById(bookmarkId);
+  }
+
+  @Test
+  @DisplayName("북마크 스테이션 미 존재 시 북마크 예외 발생")
+  void notExistBookmarkStation() {
+    //given
+    Long bookmarkId = 1L;
+
+    given(bookmarkStationRepository.existsBookmarkByEmail(EMAIL, bookmarkId)).willReturn(Boolean.FALSE);
+
+    //when then
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> userService.removeBookmarkStation(EMAIL, bookmarkId))
+        .withMessage(ErrorCode.BOOKMARK_NOT_EXIST.getMessage());
+  }
+
+}

--- a/server/src/test/java/site/bannabe/server/global/security/service/CustomUserDetailsServiceTest.java
+++ b/server/src/test/java/site/bannabe/server/global/security/service/CustomUserDetailsServiceTest.java
@@ -1,0 +1,71 @@
+package site.bannabe.server.global.security.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.util.Collections;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import site.bannabe.server.domain.users.entity.Role;
+import site.bannabe.server.domain.users.entity.Users;
+import site.bannabe.server.domain.users.repository.UserRepository;
+import site.bannabe.server.global.exceptions.BannabeServiceException;
+import site.bannabe.server.global.exceptions.ErrorCode;
+import site.bannabe.server.global.security.auth.PrincipalDetails;
+
+@ExtendWith(MockitoExtension.class)
+class CustomUserDetailsServiceTest {
+
+  @InjectMocks
+  private CustomUserDetailsService customUserDetailsService;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Test
+  @DisplayName("회원 조회 성공 시 PrincipalDetails 응답")
+  void loadUserByUsername() {
+    //given
+    String email = "test@test.com";
+    String password = "1234";
+    Users user = mock(Users.class);
+    Set<SimpleGrantedAuthority> authorities = Collections.singleton(new SimpleGrantedAuthority(Role.USER.getRoleKey()));
+
+    given(user.getEmail()).willReturn(email);
+    given(user.getRole()).willReturn(Role.USER);
+    given(user.getPassword()).willReturn(password);
+    given(userRepository.findByEmail(email)).willReturn(user);
+
+    //when
+    UserDetails userDetails = customUserDetailsService.loadUserByUsername(email);
+
+    //then
+    assertThat(userDetails).isInstanceOf(PrincipalDetails.class)
+                           .extracting("username", "password", "authorities")
+                           .containsExactly(email, password, authorities);
+  }
+
+  @Test
+  @DisplayName("회원 정보 미 존재시 UserNotFoundException 발생")
+  void notFoundUser() {
+    //given
+    String email = "test@test.com";
+    given(userRepository.findByEmail(email)).willThrow(new BannabeServiceException(ErrorCode.USER_NOT_FOUND));
+
+    //when then
+    assertThatExceptionOfType(UsernameNotFoundException.class)
+        .isThrownBy(() -> customUserDetailsService.loadUserByUsername(email))
+        .withMessage(ErrorCode.USER_NOT_FOUND.getMessage());
+  }
+
+}


### PR DESCRIPTION
## 🔍  요약
- Service 레이어 단위 테스트 추가
- JwtAuthenticationFilter 구조 개선
- Users Entity 조회 메서드 개선
- OAuth2Service 구조 개선
- GitHub Actions Workflow 추가 및 수정

## #️⃣ 연관된 이슈
x

## 🛠️ 작업 내용
### 1. Service 레이어 단위 테스트 추가
- 비즈니스 로직을 수행하는 Service 레이어의 메서드에 대한 단위 테스트를 생성하였습니다.


### 2. `JwtAuthenticationFilter` 구조 개선
- `shouldNotFilter` 메서드를 오버라이딩 해 JWT 인증이 필요없는 요청이 `JwtAuthenticationFilter`를 거치지 않도록 수정하였습니다.


### 3. Users Entity 조회 메서드 개선
- `UserRepository.findByEmail(String email)` 메서드를 QueryDSL로 리팩토링 하였습니다.
- null 반환시 메서드 내에서 `BannabeServiceException`을 발생시키도록 수정하였습니다.
- 따라서, `findByEmail()` 호출 시 `orElseThrow()`문을 삭제하였습니다.


### 4. `OAuth2Service` 구조 개선
- OAuth2 회원 정보 조회 API 호출을 `OAuth2UserInfoClient`가 담당하도록 분리하였습니다.
- `UserRepository.findByEmail(String email)` 구조 변경에 따라 try-catch 문으로 Users Entity를 바인딩 하도록 수정하였습니다.


### 5. GitHub Actions Workflow 추가 및 수정
####  `build.yml` 추가
- 재사용 가능한 워크플로우(Reusable Workflow) 로 구현하였습니다.

#### `push.yml` 추가
- `main` `develop`을 제외한 모든 브랜치 push 트리거로 동작합니다.
- Build 워크플로우를 사용해 테스트 및 빌드가 성공하는지 검증합니다.

#### `pr-events-slack.yml` 수정
- 트리거에 맞게 `pull-request.yml`로 이름을 변경하였습니다.
- `secrets`는 reusable workflow에 전달이 되지않아, slack notification job은 분리하지 않았습니다.
- build workflow 실행 후 빌드 성공 시 slack notification job으로 slack에 메시지를 전송합니다.
 

## 💬 To Other
S3, Mail, JWT 관련 테스트는 다음 PR에 추가 예정입니다.
