### PR TITLE
Feature: 반납 및 연장/연체 결제 프로세스 구현

### DIFF
--- a/server/src/main/java/site/bannabe/server/domain/payments/controller/PaymentController.java
+++ b/server/src/main/java/site/bannabe/server/domain/payments/controller/PaymentController.java
@@ -23,7 +23,6 @@ public class PaymentController {
 
   private final PaymentService paymentService;
 
-  // 결제금액이 변조되지 않도록 서버에서 계산해서 내려주는 요청
   @PreAuthorize("hasRole('USER')")
   @PostMapping("/calculate")
   public PaymentCalculateResponse calculateAmount(@RequestBody PaymentCalculateRequest paymentRequest) {

--- a/server/src/main/java/site/bannabe/server/domain/payments/service/PaymentService.java
+++ b/server/src/main/java/site/bannabe/server/domain/payments/service/PaymentService.java
@@ -12,6 +12,7 @@ import site.bannabe.server.domain.payments.repository.RentalPaymentRepository;
 import site.bannabe.server.domain.rentals.entity.RentalHistory;
 import site.bannabe.server.domain.rentals.entity.RentalItems;
 import site.bannabe.server.domain.rentals.repository.RentalItemRepository;
+import site.bannabe.server.domain.rentals.service.StockLockService;
 import site.bannabe.server.domain.users.entity.Users;
 import site.bannabe.server.domain.users.repository.UserRepository;
 import site.bannabe.server.global.api.TossPaymentApiClient;
@@ -29,7 +30,7 @@ public class PaymentService {
   private final UserRepository userRepository;
   private final TossPaymentApiClient tossApiClient;
   private final OrderInfoService orderInfoService;
-  private final PaymentLockService paymentLockService;
+  private final StockLockService stockLockService;
 
   @Transactional(readOnly = true)
   public PaymentCalculateResponse calculateAmount(PaymentCalculateRequest paymentRequest) {
@@ -71,7 +72,7 @@ public class PaymentService {
   }
 
   private void processRental(PaymentConfirmRequest paymentConfirmRequest, RentalItems rentalItem) {
-    paymentLockService.decreaseStock(rentalItem);
+    stockLockService.decreaseStock(rentalItem);
     rentalItem.rentOut();
     orderInfoService.removeOrderInfo(paymentConfirmRequest.orderId());
   }

--- a/server/src/main/java/site/bannabe/server/domain/payments/service/PaymentViewService.java
+++ b/server/src/main/java/site/bannabe/server/domain/payments/service/PaymentViewService.java
@@ -42,7 +42,7 @@ public class PaymentViewService {
 
   private void validateOrderInfoNotExist(String rentalItemToken) {
     if (orderInfoService.isExistOrderInfo(rentalItemToken)) {
-      throw new BannabeServiceException(ErrorCode.ALREADY_EXIST_ORDER_INFO);
+      throw new BannabeServiceException(ErrorCode.ORDER_INFO_EXISTS);
     }
   }
 

--- a/server/src/main/java/site/bannabe/server/domain/rentals/controller/ReturnController.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/controller/ReturnController.java
@@ -1,0 +1,19 @@
+package site.bannabe.server.domain.rentals.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/returns")
+@RequiredArgsConstructor
+public class ReturnController {
+
+  @GetMapping("/{rentalItemToken}")
+  public void getReturnItemInfo(@PathVariable("rentalItemToken") String rentalItemToken){
+
+  }
+
+}

--- a/server/src/main/java/site/bannabe/server/domain/rentals/controller/ReturnController.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/controller/ReturnController.java
@@ -3,17 +3,38 @@ package site.bannabe.server.domain.rentals.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import site.bannabe.server.domain.rentals.controller.request.ReturnStationRequest;
+import site.bannabe.server.domain.rentals.controller.response.ReturnItemDetailResponse;
+import site.bannabe.server.domain.rentals.service.ReturnService;
 
 @RestController
 @RequestMapping("/v1/returns")
 @RequiredArgsConstructor
 public class ReturnController {
 
-  @GetMapping("/{rentalItemToken}")
-  public void getReturnItemInfo(@PathVariable("rentalItemToken") String rentalItemToken){
+  private final ReturnService returnService;
 
+  //  @PreAuthorize("hasRole('STATION')")
+  @GetMapping("/{rentalItemToken}")
+  public ReturnItemDetailResponse getReturnItemInfo(
+      @PathVariable("rentalItemToken") String rentalItemToken,
+      @RequestParam("currentStationId") Long currentStationId
+  ) {
+    return returnService.getReturnItemInfo(rentalItemToken, currentStationId);
+  }
+
+  //  @PreAuthorize("hasRole('STATION')")
+  @PostMapping("/{rentalItemToken}")
+  public void returnItem(
+      @PathVariable("rentalItemToken") String rentalItemToken,
+      @RequestBody ReturnStationRequest returnStationRequest
+  ) {
+    returnService.returnRentalItem(rentalItemToken, returnStationRequest.returnStationId());
   }
 
 }

--- a/server/src/main/java/site/bannabe/server/domain/rentals/controller/request/ReturnStationRequest.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/controller/request/ReturnStationRequest.java
@@ -1,0 +1,7 @@
+package site.bannabe.server.domain.rentals.controller.request;
+
+public record ReturnStationRequest(
+    Long returnStationId
+) {
+
+}

--- a/server/src/main/java/site/bannabe/server/domain/rentals/controller/response/ReturnItemDetailResponse.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/controller/response/ReturnItemDetailResponse.java
@@ -1,0 +1,50 @@
+package site.bannabe.server.domain.rentals.controller.response;
+
+import java.time.LocalDateTime;
+import site.bannabe.server.domain.rentals.entity.RentalHistory;
+import site.bannabe.server.domain.rentals.entity.RentalStations;
+
+public record ReturnItemDetailResponse(
+    String rentalItemName,
+    RentalHistoryResponse rentalHistory,
+    RentalStationResponse rentalStation
+) {
+
+  public static ReturnItemDetailResponse from(RentalHistory rentalHistory, RentalStations currentStation) {
+    return new ReturnItemDetailResponse(
+        rentalHistory.getRentalItem().getRentalItemType().getName(),
+        RentalHistoryResponse.from(rentalHistory),
+        RentalStationResponse.from(rentalHistory.getRentalStation(), currentStation)
+    );
+  }
+
+  public record RentalHistoryResponse(
+      String status,
+      Integer rentalTime,
+      LocalDateTime startTime,
+      LocalDateTime expectedReturnTime
+  ) {
+
+    private static RentalHistoryResponse from(RentalHistory rentalHistory) {
+      return new RentalHistoryResponse(
+          rentalHistory.getStatus().name(),
+          rentalHistory.getRentalTimeHour(),
+          rentalHistory.getStartTime(),
+          rentalHistory.getExpectedReturnTime()
+      );
+    }
+  }
+
+  public record RentalStationResponse(
+      String rentalStationName,
+      String currentStationName
+  ) {
+
+    private static RentalStationResponse from(RentalStations rentalStation, RentalStations currentStation) {
+      return new RentalStationResponse(
+          rentalStation.getName(),
+          currentStation.getName()
+      );
+    }
+  }
+}

--- a/server/src/main/java/site/bannabe/server/domain/rentals/entity/RentalHistory.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/entity/RentalHistory.java
@@ -32,7 +32,8 @@ public class RentalHistory extends BaseEntity {
 
   private Integer rentalTimeHour;
 
-  private String token;
+  @Default
+  private String token = RandomCodeGenerator.generateRandomToken(RentalHistory.class);
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id")
@@ -70,7 +71,6 @@ public class RentalHistory extends BaseEntity {
                         .startTime(startTime)
                         .expectedReturnTime(startTime.plusHours(orderInfo.getRentalTime()))
                         .rentalTimeHour(orderInfo.getRentalTime())
-                        .token(RandomCodeGenerator.generateRandomToken(RentalHistory.class))
                         .user(user)
                         .rentalItem(rentalItem)
                         .rentalStation(rentalItem.getCurrentStation())
@@ -79,6 +79,12 @@ public class RentalHistory extends BaseEntity {
 
   public void changeStatus(RentalStatus status) {
     this.status = status;
+  }
+
+  public void updateOnReturn(RentalStations returnStation, LocalDateTime returnTime) {
+    changeStatus(RentalStatus.RETURNED);
+    this.returnStation = returnStation;
+    this.returnTime = returnTime;
   }
 
   public boolean isOverdue(LocalDateTime now) {

--- a/server/src/main/java/site/bannabe/server/domain/rentals/entity/RentalHistory.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/entity/RentalHistory.java
@@ -81,6 +81,11 @@ public class RentalHistory extends BaseEntity {
     this.status = status;
   }
 
+  public void extendRentalTime(Integer rentalTime) {
+    this.expectedReturnTime = this.expectedReturnTime.plusHours(rentalTime);
+    this.rentalTimeHour += rentalTime;
+  }
+
   public void updateOnReturn(RentalStations returnStation, LocalDateTime returnTime) {
     changeStatus(RentalStatus.RETURNED);
     this.returnStation = returnStation;
@@ -88,7 +93,7 @@ public class RentalHistory extends BaseEntity {
   }
 
   public boolean isOverdue(LocalDateTime now) {
-    return !this.expectedReturnTime.isAfter(now);
+    return this.expectedReturnTime.isBefore(now);
   }
 
   public void validateOverdue(LocalDateTime now) {

--- a/server/src/main/java/site/bannabe/server/domain/rentals/entity/RentalHistory.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/entity/RentalHistory.java
@@ -97,7 +97,7 @@ public class RentalHistory extends BaseEntity {
   }
 
   public void validateOverdue(LocalDateTime now) {
-    if (this.status.equals(RentalStatus.RENTAL) && isOverdue(now)) {
+    if ((this.status.equals(RentalStatus.RENTAL) || this.status.equals(RentalStatus.EXTENSION)) && isOverdue(now)) {
       changeStatus(RentalStatus.OVERDUE);
     }
   }

--- a/server/src/main/java/site/bannabe/server/domain/rentals/entity/RentalItems.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/entity/RentalItems.java
@@ -46,4 +46,13 @@ public class RentalItems extends BaseEntity {
     this.currentStation = null;
   }
 
+  public boolean isRented() {
+    return this.status.equals(RentalItemStatus.RENTED);
+  }
+
+  public void updateOnReturn(RentalStations currentStation) {
+    this.status = RentalItemStatus.AVAILABLE;
+    this.currentStation = currentStation;
+  }
+
 }

--- a/server/src/main/java/site/bannabe/server/domain/rentals/entity/RentalStationItems.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/entity/RentalStationItems.java
@@ -39,4 +39,8 @@ public class RentalStationItems extends BaseEntity {
     this.stock--;
   }
 
+  public void increaseStock() {
+    this.stock++;
+  }
+
 }

--- a/server/src/main/java/site/bannabe/server/domain/rentals/entity/RentalStatus.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/entity/RentalStatus.java
@@ -12,7 +12,8 @@ public enum RentalStatus {
   RENTAL("대여중"),
   EXTENSION("연장"),
   OVERDUE("연체"),
-  RETURN("반납");
+  OVERDUE_PAID("연체 납부"),
+  RETURNED("반납");
 
   private final String description;
 

--- a/server/src/main/java/site/bannabe/server/domain/rentals/repository/querydsl/CustomRentalHistoryRepository.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/repository/querydsl/CustomRentalHistoryRepository.java
@@ -14,4 +14,6 @@ public interface CustomRentalHistoryRepository {
 
   RentalSuccessSimpleResponse findRentalHistoryInfoBy(String token);
 
+  RentalHistory findByItemToken(String rentalItemToken);
+
 }

--- a/server/src/main/java/site/bannabe/server/domain/rentals/repository/querydsl/CustomRentalHistoryRepositoryImpl.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/repository/querydsl/CustomRentalHistoryRepositoryImpl.java
@@ -1,5 +1,13 @@
 package site.bannabe.server.domain.rentals.repository.querydsl;
 
+import static site.bannabe.server.domain.payments.entity.QRentalPayments.rentalPayments;
+import static site.bannabe.server.domain.rentals.entity.QRentalHistory.rentalHistory;
+import static site.bannabe.server.domain.rentals.entity.QRentalItemTypes.rentalItemTypes;
+import static site.bannabe.server.domain.rentals.entity.QRentalItems.rentalItems;
+import static site.bannabe.server.domain.rentals.entity.QRentalStations.rentalStations;
+import static site.bannabe.server.domain.rentals.entity.RentalStatus.OVERDUE;
+import static site.bannabe.server.domain.rentals.entity.RentalStatus.RENTAL;
+
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
@@ -14,15 +22,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
-import static site.bannabe.server.domain.payments.entity.QRentalPayments.rentalPayments;
 import site.bannabe.server.domain.rentals.controller.response.RentalSuccessSimpleResponse;
-import static site.bannabe.server.domain.rentals.entity.QRentalHistory.rentalHistory;
-import static site.bannabe.server.domain.rentals.entity.QRentalItemTypes.rentalItemTypes;
-import static site.bannabe.server.domain.rentals.entity.QRentalItems.rentalItems;
-import static site.bannabe.server.domain.rentals.entity.QRentalStations.rentalStations;
 import site.bannabe.server.domain.rentals.entity.RentalHistory;
-import static site.bannabe.server.domain.rentals.entity.RentalStatus.OVERDUE;
-import static site.bannabe.server.domain.rentals.entity.RentalStatus.RENTAL;
 import site.bannabe.server.global.exceptions.BannabeServiceException;
 import site.bannabe.server.global.exceptions.ErrorCode;
 
@@ -78,6 +79,15 @@ public class CustomRentalHistoryRepositoryImpl implements CustomRentalHistoryRep
                                                         .where(rentalHistory.token.eq(token))
                                                         .fetchOne();
     return Optional.ofNullable(result).orElseThrow(() -> new BannabeServiceException(ErrorCode.ORDER_INFO_NOT_FOUND));
+  }
+
+  @Override
+  public RentalHistory findByItemToken(String rentalItemToken) {
+    RentalHistory result = jpaQueryFactory.selectFrom(rentalHistory)
+                                          .join(rentalHistory.rentalItem, rentalItems).fetchJoin()
+                                          .join(rentalItems.rentalItemType, rentalItemTypes).fetchJoin()
+                                          .where(rentalItems.token.eq(rentalItemToken)).fetchOne();
+    return Optional.ofNullable(result).orElseThrow(() -> new BannabeServiceException(ErrorCode.RENTAL_HISTORY_NOT_FOUND));
   }
 
   @SuppressWarnings("unchecked")

--- a/server/src/main/java/site/bannabe/server/domain/rentals/service/RentalService.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/service/RentalService.java
@@ -8,6 +8,8 @@ import site.bannabe.server.domain.rentals.controller.response.RentalSuccessSimpl
 import site.bannabe.server.domain.rentals.entity.RentalItems;
 import site.bannabe.server.domain.rentals.repository.RentalHistoryRepository;
 import site.bannabe.server.domain.rentals.repository.RentalItemRepository;
+import site.bannabe.server.global.exceptions.BannabeServiceException;
+import site.bannabe.server.global.exceptions.ErrorCode;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +21,9 @@ public class RentalService {
   @Transactional(readOnly = true)
   public RentalItemDetailResponse getRentalItemInfo(String rentalItemToken) {
     RentalItems rentalItem = rentalItemRepository.findByToken(rentalItemToken);
+    if (rentalItem.isRented()) {
+      throw new BannabeServiceException(ErrorCode.RENTAL_ITEM_ALREADY_RENTED);
+    }
     return RentalItemDetailResponse.create(rentalItem);
   }
 

--- a/server/src/main/java/site/bannabe/server/domain/rentals/service/ReturnService.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/service/ReturnService.java
@@ -1,0 +1,30 @@
+package site.bannabe.server.domain.rentals.service;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.bannabe.server.domain.rentals.entity.RentalHistory;
+import site.bannabe.server.domain.rentals.entity.RentalStatus;
+import site.bannabe.server.domain.rentals.repository.RentalHistoryRepository;
+
+@Service
+@RequiredArgsConstructor
+public class ReturnService {
+
+  private final RentalHistoryRepository rentalHistoryRepository;
+
+
+  @Transactional(readOnly = true)
+  public void getReturnItemInfo(String rentalItemToken) {
+    RentalHistory rentalHistory = rentalHistoryRepository.findByItemToken(rentalItemToken);
+    // 현재시간 보다 expectedReturnTime이 빠르면 OVERDUE로 변경
+    if (rentalHistory.getExpectedReturnTime().isBefore(LocalDateTime.now())) {
+      rentalHistory.changeStatus(RentalStatus.OVERDUE);
+    }
+    // 여기서 OVERDUE라면 변경하고 예외터트려서 클라이언트에서 연체 유도하도록 처리
+    // RETURNED라면 이미 반납한거지 예외 터트림
+    // 그 외에는 DTO로 변환해서 응답
+  }
+
+}

--- a/server/src/main/java/site/bannabe/server/domain/rentals/service/StockLockService.java
+++ b/server/src/main/java/site/bannabe/server/domain/rentals/service/StockLockService.java
@@ -1,4 +1,4 @@
-package site.bannabe.server.domain.payments.service;
+package site.bannabe.server.domain.rentals.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,7 +11,7 @@ import site.bannabe.server.global.aop.DistributedLock;
 
 @Service
 @RequiredArgsConstructor
-public class PaymentLockService {
+public class StockLockService {
 
   private final RentalStationItemRepository rentalStationItemRepository;
 
@@ -21,6 +21,14 @@ public class PaymentLockService {
     RentalStations currentStation = rentalItem.getCurrentStation();
     RentalStationItems rentalStationItem = rentalStationItemRepository.findByItemTypeAndStation(rentalItemType, currentStation);
     rentalStationItem.decreaseStock();
+  }
+
+  @DistributedLock(key = "'station:' + #rentalItem.getCurrentStation().getId() + ':itemType:' + #rentalItem.getRentalItemType().getId()")
+  public void increaseStock(RentalItems rentalItem) {
+    RentalItemTypes rentalItemType = rentalItem.getRentalItemType();
+    RentalStations currentStation = rentalItem.getCurrentStation();
+    RentalStationItems rentalStationItem = rentalStationItemRepository.findByItemTypeAndStation(rentalItemType, currentStation);
+    rentalStationItem.increaseStock();
   }
 
 }

--- a/server/src/main/java/site/bannabe/server/domain/users/controller/OAuth2Controller.java
+++ b/server/src/main/java/site/bannabe/server/domain/users/controller/OAuth2Controller.java
@@ -4,18 +4,20 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import site.bannabe.server.domain.users.controller.request.OAuth2AuthorizationRequest;
 import site.bannabe.server.domain.users.service.OAuth2Service;
 import site.bannabe.server.global.type.TokenResponse;
 
 @RestController
+@RequestMapping("/v1/oauth2")
 @RequiredArgsConstructor
 public class OAuth2Controller {
 
   private final OAuth2Service oAuth2Service;
 
-  @PostMapping("/oauth2/login/{provider}")
+  @PostMapping("/login/{provider}")
   public TokenResponse loginWithOAuth2(@PathVariable String provider,
       @RequestBody OAuth2AuthorizationRequest authorizationRequest) {
     return oAuth2Service.processOAuth2Login(provider, authorizationRequest);

--- a/server/src/main/java/site/bannabe/server/global/exceptions/ErrorCode.java
+++ b/server/src/main/java/site/bannabe/server/global/exceptions/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
   RENTAL_STATION_NOT_FOUND(HttpStatus.NOT_FOUND, "대여소 정보가 존재하지 않습니다."),
   RENTAL_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "대여물품 정보가 존재하지 않습니다."),
   RENTAL_STATION_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "대여소 대여물품 정보가 존재하지 않습니다."),
+  RENTAL_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND,"대여내역이 존재하지 않습니다." ),
 
   // 409 CONFLICT
   NEW_PASSWORD_MISMATCH(HttpStatus.CONFLICT, "새 비밀번호가 일치하지 않습니다."),

--- a/server/src/main/java/site/bannabe/server/global/exceptions/ErrorCode.java
+++ b/server/src/main/java/site/bannabe/server/global/exceptions/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
   RENTAL_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "대여물품 정보가 존재하지 않습니다."),
   RENTAL_STATION_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "대여소 대여물품 정보가 존재하지 않습니다."),
   RENTAL_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "대여내역이 존재하지 않습니다."),
+  USER_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 토큰이 존재하지 않습니다."),
 
   // 409 CONFLICT
   NEW_PASSWORD_MISMATCH(HttpStatus.CONFLICT, "새 비밀번호가 일치하지 않습니다."),

--- a/server/src/main/java/site/bannabe/server/global/exceptions/ErrorCode.java
+++ b/server/src/main/java/site/bannabe/server/global/exceptions/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
   VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "요청 데이터가 올바르지 않습니다."),
   INVALID_LOGIN_CREDENTIALS(HttpStatus.BAD_REQUEST, "로그인에 실패했습니다. 이메일 또는 비밀번호를 확인해주세요."),
   INVALID_S3_URL_FORMAT(HttpStatus.BAD_REQUEST, "S3 URL 형식이 올바르지 않습니다."),
+  RENTAL_ITEM_NOT_RENTED(HttpStatus.BAD_REQUEST, "대여되지 않은 물품입니다."),
 
   // 401 UNAUTHORIZED
   UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "사용자 인증이 필요합니다."),
@@ -25,6 +26,7 @@ public enum ErrorCode {
 
   // 403 FORBIDDEN
   FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+  RENTAL_ITEM_OVERDUE(HttpStatus.FORBIDDEN, "연체된 물품은 반납할 수 없습니다. 결제를 진행해주세요."),
 
   // 404 NOT_FOUND
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원정보가 존재하지 않습니다."),
@@ -35,7 +37,7 @@ public enum ErrorCode {
   RENTAL_STATION_NOT_FOUND(HttpStatus.NOT_FOUND, "대여소 정보가 존재하지 않습니다."),
   RENTAL_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "대여물품 정보가 존재하지 않습니다."),
   RENTAL_STATION_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "대여소 대여물품 정보가 존재하지 않습니다."),
-  RENTAL_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND,"대여내역이 존재하지 않습니다." ),
+  RENTAL_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "대여내역이 존재하지 않습니다."),
 
   // 409 CONFLICT
   NEW_PASSWORD_MISMATCH(HttpStatus.CONFLICT, "새 비밀번호가 일치하지 않습니다."),
@@ -49,8 +51,9 @@ public enum ErrorCode {
   ALREADY_BOOKMARKED(HttpStatus.CONFLICT, "이미 즐겨찾기한 대여 스테이션입니다."),
   AMOUNT_MISMATCH(HttpStatus.CONFLICT, "금액이 일치하지 않습니다."),
   LOCK_CONFLICT(HttpStatus.CONFLICT, "현재 요청이 많아 처리가 지연되고 있습니다. 다시 시도해주세요."),
-  ALREADY_EXIST_ORDER_INFO(HttpStatus.CONFLICT, "해당 대여물품에 대한 주문 정보가 이미 존재합니다."),
-  RENTAL_ITEM_STOCK_EMPTY(HttpStatus.CONFLICT, "대여물품 재고가 없습니다."),
+  ORDER_INFO_EXISTS(HttpStatus.CONFLICT, "해당 대여물품에 대한 주문 정보가 이미 존재합니다."),
+  RENTAL_ITEM_STOCK_EMPTY(HttpStatus.CONFLICT, "대여물품 재고가 부족합니다."),
+  RENTAL_ITEM_ALREADY_RENTED(HttpStatus.CONFLICT, "해당 물품은 이미 대여 중 입니다."),
 
   // 500 INTERNAL_SERVER_ERROR
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류입니다. 관리자에게 문의하세요."),

--- a/server/src/main/java/site/bannabe/server/global/jwt/UserTokenService.java
+++ b/server/src/main/java/site/bannabe/server/global/jwt/UserTokenService.java
@@ -1,5 +1,6 @@
 package site.bannabe.server.global.jwt;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import site.bannabe.server.global.redis.UserTokenClient;
@@ -23,6 +24,10 @@ public class UserTokenService {
 
   public UserTokens findBy(String key, String refreshToken) {
     return userTokenClient.findBy(key, refreshToken);
+  }
+
+  public List<UserTokens> findAllUserTokens(String key) {
+    return userTokenClient.findAll(key);
   }
 
   public void removeUserToken(String key, String refreshToken) {

--- a/server/src/main/java/site/bannabe/server/global/redis/UserTokenClient.java
+++ b/server/src/main/java/site/bannabe/server/global/redis/UserTokenClient.java
@@ -1,6 +1,8 @@
 package site.bannabe.server.global.redis;
 
 import java.time.Duration;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +34,19 @@ public class UserTokenClient implements RedisHashClient<UserTokens> {
     return Optional.ofNullable(deviceToken)
                    .map(token -> new UserTokens(hashKey, token))
                    .orElseThrow(() -> new BannabeServiceException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
+  }
+
+  public List<UserTokens> findAll(String key) {
+    key = generateKey(USER_TOKEN_FORMAT, key);
+    Map<Object, Object> entries = redis.opsForHash().entries(key);
+
+    if (entries.isEmpty()) {
+      throw new BannabeServiceException(ErrorCode.USER_TOKEN_NOT_FOUND);
+    }
+
+    return entries.entrySet().stream()
+                  .map(entry -> new UserTokens(String.valueOf(entry.getKey()), String.valueOf(entry.getValue())))
+                  .toList();
   }
 
   @Override

--- a/server/src/main/java/site/bannabe/server/global/security/auth/EndPoint.java
+++ b/server/src/main/java/site/bannabe/server/global/security/auth/EndPoint.java
@@ -30,7 +30,7 @@ public record EndPoint(
       new EndPoint(HttpMethod.GET, "/v1/payments/failure"),
       new EndPoint(HttpMethod.GET, "/payment-test"),
       new EndPoint(HttpMethod.GET, "/payment-complete"),
-      new EndPoint(HttpMethod.POST, "/oauth2/login/{provider}")
+      new EndPoint(HttpMethod.POST, "/v1/oauth2/login/{provider}")
   );
 
   public static final List<RequestMatcher> PERMIT_ALL_MATCHERS = Stream.concat(

--- a/server/src/test/java/site/bannabe/server/domain/payments/service/PaymentServiceTest.java
+++ b/server/src/test/java/site/bannabe/server/domain/payments/service/PaymentServiceTest.java
@@ -26,6 +26,7 @@ import site.bannabe.server.domain.payments.repository.RentalPaymentRepository;
 import site.bannabe.server.domain.rentals.entity.RentalItems;
 import site.bannabe.server.domain.rentals.entity.RentalStations;
 import site.bannabe.server.domain.rentals.repository.RentalItemRepository;
+import site.bannabe.server.domain.rentals.service.StockLockService;
 import site.bannabe.server.domain.users.entity.Users;
 import site.bannabe.server.domain.users.repository.UserRepository;
 import site.bannabe.server.global.api.TossPaymentApiClient;
@@ -59,7 +60,7 @@ class PaymentServiceTest {
   @Mock
   private OrderInfoService orderInfoService;
   @Mock
-  private PaymentLockService paymentLockService;
+  private StockLockService stockLockService;
 
   @Test
   @DisplayName("최종 결제 금액 계산 후 데이터 응답")
@@ -110,7 +111,7 @@ class PaymentServiceTest {
     verify(rentalItemRepository).findByToken(orderInfo.getRentalItemToken());
     verify(userRepository).findByToken(entityToken);
     verify(rentalPaymentRepository).save(any(RentalPayments.class));
-    verify(paymentLockService).decreaseStock(mockItem);
+    verify(stockLockService).decreaseStock(mockItem);
     verify(mockItem).rentOut();
     verify(orderInfoService).removeOrderInfo(confirmRequest.orderId());
   }
@@ -132,7 +133,7 @@ class PaymentServiceTest {
     verify(rentalItemRepository, never()).findByToken(rentalItemToken);
     verify(userRepository, never()).findByToken(entityToken);
     verify(rentalPaymentRepository, never()).save(any(RentalPayments.class));
-    verify(paymentLockService, never()).decreaseStock(any(RentalItems.class));
+    verify(stockLockService, never()).decreaseStock(any(RentalItems.class));
     verify(orderInfoService, never()).removeOrderInfo(confirmRequest.orderId());
   }
 

--- a/server/src/test/java/site/bannabe/server/domain/payments/service/PaymentViewServiceTest.java
+++ b/server/src/test/java/site/bannabe/server/domain/payments/service/PaymentViewServiceTest.java
@@ -84,7 +84,7 @@ class PaymentViewServiceTest {
     //when then
     assertThatExceptionOfType(BannabeServiceException.class)
         .isThrownBy(() -> paymentViewService.getPaymentRequest(rentalItemToken, rentalTime, paymentType))
-        .withMessage(ErrorCode.ALREADY_EXIST_ORDER_INFO.getMessage());
+        .withMessage(ErrorCode.ORDER_INFO_EXISTS.getMessage());
 
     verify(rentalItemRepository, never()).findByToken(anyString());
     verify(orderInfoService, never()).saveOrderInfo(anyString(), eq(rentalItemToken), eq(rentalTime), anyInt(), eq(paymentType));

--- a/server/src/test/java/site/bannabe/server/domain/rentals/repository/RentalHistoryRepositoryTest.java
+++ b/server/src/test/java/site/bannabe/server/domain/rentals/repository/RentalHistoryRepositoryTest.java
@@ -194,6 +194,57 @@ class RentalHistoryRepositoryTest extends AbstractTestContainers {
     em.clear();
   }
 
+  @Test
+  @Transactional
+  @DisplayName("대여물품 토큰 기반 대여내역 조회 테스트")
+  void findByItemToken() {
+    //given
+    String rentalItemToken = "rentalItemToken";
+    String itemName = "65W충전기";
+    String stationName = "대여스테이션";
+    LocalDateTime now = LocalDateTime.now();
+    int rentalTimeHour = 2;
+    RentalItemTypes itemType = RentalItemTypes.builder().name(itemName).category(RentalItemCategory.CHARGER).price(2000).build();
+    em.persist(itemType);
+
+    RentalItems rentalItem = RentalItems.builder()
+                                        .status(RentalItemStatus.RENTED)
+                                        .token(rentalItemToken)
+                                        .rentalItemType(itemType)
+                                        .build();
+
+    em.persist(rentalItem);
+    RentalStations station = RentalStations.builder()
+                                           .name(stationName)
+                                           .grade(StationGrade.FIRST)
+                                           .status(StationStatus.OPEN)
+                                           .build();
+    em.persist(station);
+    RentalHistory rentalHistory = RentalHistory.builder()
+                                               .rentalItem(rentalItem)
+                                               .user(user)
+                                               .rentalTimeHour(rentalTimeHour)
+                                               .startTime(now)
+                                               .expectedReturnTime(now.plusHours(rentalTimeHour))
+                                               .rentalStation(station)
+                                               .build();
+    em.persist(rentalHistory);
+    em.flush();
+    em.clear();
+
+    //when
+    RentalHistory result = rentalHistoryRepository.findByItemToken(rentalItemToken);
+
+    //then
+    assertThat(result).isNotNull()
+                      .extracting(RentalHistory::getRentalTimeHour).isEqualTo(rentalTimeHour);
+    assertThat(result.getRentalItem().getRentalItemType()).isNotNull()
+                                                          .extracting(RentalItemTypes::getName)
+                                                          .isEqualTo(itemName);
+    assertThat(result.getRentalStation()).isNotNull()
+                                         .extracting(RentalStations::getName)
+                                         .isEqualTo(stationName);
+  }
 
   private RentalHistory createRentalHistory(int index, RentalStatus status, LocalDateTime now) {
     return RentalHistory.builder()

--- a/server/src/test/java/site/bannabe/server/domain/rentals/repository/RentalHistoryRepositoryTest.java
+++ b/server/src/test/java/site/bannabe/server/domain/rentals/repository/RentalHistoryRepositoryTest.java
@@ -92,7 +92,7 @@ class RentalHistoryRepositoryTest extends AbstractTestContainers {
       RentalStatus status = i % 2 == 0 ? RentalStatus.RENTAL : RentalStatus.OVERDUE;
       rentalHistories.add(createRentalHistory(i, status, now));
     }
-    rentalHistories.add(createRentalHistory(5, RentalStatus.RETURN, now.minusDays(1)));
+    rentalHistories.add(createRentalHistory(5, RentalStatus.RETURNED, now.minusDays(1)));
     rentalHistoryRepository.saveAllAndFlush(rentalHistories);
 
     //when
@@ -115,7 +115,7 @@ class RentalHistoryRepositoryTest extends AbstractTestContainers {
       RentalStatus status = switch (i % 3) {
         case 0 -> RentalStatus.RENTAL;
         case 1 -> RentalStatus.OVERDUE;
-        default -> RentalStatus.RETURN;
+        default -> RentalStatus.RETURNED;
       };
       rentalHistories.add(createRentalHistory(i, status, now));
     }

--- a/server/src/test/java/site/bannabe/server/domain/rentals/service/RentalServiceTest.java
+++ b/server/src/test/java/site/bannabe/server/domain/rentals/service/RentalServiceTest.java
@@ -1,0 +1,81 @@
+package site.bannabe.server.domain.rentals.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import site.bannabe.server.domain.rentals.controller.response.RentalItemDetailResponse;
+import site.bannabe.server.domain.rentals.entity.RentalItemStatus;
+import site.bannabe.server.domain.rentals.entity.RentalItemTypes;
+import site.bannabe.server.domain.rentals.entity.RentalItems;
+import site.bannabe.server.domain.rentals.entity.RentalStations;
+import site.bannabe.server.domain.rentals.repository.RentalItemRepository;
+import site.bannabe.server.global.exceptions.BannabeServiceException;
+import site.bannabe.server.global.exceptions.ErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class RentalServiceTest {
+
+  @InjectMocks
+  private RentalService rentalService;
+
+  @Mock
+  private RentalItemRepository rentalItemRepository;
+
+  @Test
+  @DisplayName("대여 아이템 정보 조회 성공")
+  void getRentalItemInfo() {
+    //given
+    String rentalItemToken = "rentalItemToken";
+    String itemName = "Rental Item";
+    int price = 1000;
+    String stationName = "테스트 스테이션";
+    RentalItemTypes mockItemType = mock(RentalItemTypes.class);
+    RentalStations mockStation = mock(RentalStations.class);
+
+    RentalItems rentalItem = RentalItems.builder()
+                                        .rentalItemType(mockItemType)
+                                        .token(rentalItemToken)
+                                        .status(RentalItemStatus.AVAILABLE)
+                                        .currentStation(mockStation)
+                                        .build();
+
+    given(mockItemType.getName()).willReturn(itemName);
+    given(mockItemType.getPrice()).willReturn(price);
+    given(mockStation.getName()).willReturn(stationName);
+    given(rentalItemRepository.findByToken(rentalItemToken)).willReturn(rentalItem);
+
+    //when
+    RentalItemDetailResponse result = rentalService.getRentalItemInfo(rentalItemToken);
+
+    //then
+    assertThat(result).isNotNull()
+                      .extracting(
+                          RentalItemDetailResponse::name,
+                          RentalItemDetailResponse::price,
+                          RentalItemDetailResponse::currentStationName
+                      ).containsExactly(itemName, price, stationName);
+  }
+
+  @Test
+  @DisplayName("이미 대여 중인 물품일 시 예외 발생")
+  void isRentedItem() {
+    //given
+    String rentalItemToken = "rentalItemToken";
+    RentalItems item = RentalItems.builder().status(RentalItemStatus.RENTED).build();
+
+    given(rentalItemRepository.findByToken(rentalItemToken)).willReturn(item);
+
+    //when then
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> rentalService.getRentalItemInfo(rentalItemToken))
+        .withMessage(ErrorCode.RENTAL_ITEM_ALREADY_RENTED.getMessage());
+  }
+}

--- a/server/src/test/java/site/bannabe/server/domain/rentals/service/ReturnServiceTest.java
+++ b/server/src/test/java/site/bannabe/server/domain/rentals/service/ReturnServiceTest.java
@@ -1,0 +1,169 @@
+package site.bannabe.server.domain.rentals.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import site.bannabe.server.domain.rentals.controller.response.ReturnItemDetailResponse;
+import site.bannabe.server.domain.rentals.entity.RentalHistory;
+import site.bannabe.server.domain.rentals.entity.RentalItemTypes;
+import site.bannabe.server.domain.rentals.entity.RentalItems;
+import site.bannabe.server.domain.rentals.entity.RentalStations;
+import site.bannabe.server.domain.rentals.entity.RentalStatus;
+import site.bannabe.server.domain.rentals.repository.RentalHistoryRepository;
+import site.bannabe.server.domain.rentals.repository.RentalStationRepository;
+import site.bannabe.server.global.exceptions.BannabeServiceException;
+import site.bannabe.server.global.exceptions.ErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class ReturnServiceTest {
+
+  @InjectMocks
+  private ReturnService returnService;
+
+  @Mock
+  private RentalHistoryRepository rentalHistoryRepository;
+  @Mock
+  private RentalStationRepository rentalStationRepository;
+  @Mock
+  private StockLockService stockLockService;
+
+  @Test
+  @DisplayName("반납 물품 데이터 조회 성공")
+  void getReturnItemInfo() {
+    //given
+    String rentalItemToken = "rentalItemToken";
+    Long currentStationId = 1L;
+    LocalDateTime startTime = LocalDateTime.now().plusHours(1);
+    int rentalTime = 1;
+    String itemName = "충전기";
+    String rentalStationName = "대여한 스테이션";
+    String currentStationName = "현재 스테이션";
+
+    RentalItems mockItem = mock(RentalItems.class);
+    RentalItemTypes mockItemType = mock(RentalItemTypes.class);
+    RentalStations rentalStation = mock(RentalStations.class);
+    RentalStations currentStation = mock(RentalStations.class);
+
+    RentalHistory rentalHistory = RentalHistory.builder()
+                                               .status(RentalStatus.RENTAL)
+                                               .rentalTimeHour(rentalTime)
+                                               .startTime(startTime)
+                                               .expectedReturnTime(startTime.plusHours(rentalTime))
+                                               .rentalItem(mockItem)
+                                               .rentalStation(rentalStation)
+                                               .build();
+
+    given(mockItem.getRentalItemType()).willReturn(mockItemType);
+    given(mockItem.isRented()).willReturn(true);
+    given(mockItemType.getName()).willReturn(itemName);
+    given(rentalStation.getName()).willReturn(rentalStationName);
+    given(currentStation.getName()).willReturn(currentStationName);
+    given(rentalHistoryRepository.findByItemToken(rentalItemToken)).willReturn(rentalHistory);
+    given(rentalStationRepository.findById(currentStationId)).willReturn(Optional.of(currentStation));
+
+    //when
+    ReturnItemDetailResponse result = returnService.getReturnItemInfo(rentalItemToken, currentStationId);
+
+    //then
+    assertThat(result).isNotNull()
+                      .extracting(
+                          ReturnItemDetailResponse::rentalItemName,
+                          r -> r.rentalHistory().status(),
+                          r -> r.rentalHistory().rentalTime(),
+                          r -> r.rentalHistory().startTime(),
+                          r -> r.rentalHistory().expectedReturnTime(),
+                          r -> r.rentalStation().rentalStationName(),
+                          r -> r.rentalStation().currentStationName()
+                      )
+                      .containsExactly(
+                          itemName,
+                          RentalStatus.RENTAL.name(),
+                          rentalTime,
+                          startTime,
+                          startTime.plusHours(rentalTime),
+                          rentalStationName,
+                          currentStationName
+                      );
+  }
+
+  @Test
+  @DisplayName("대여하지 않은 물품일 시 예외 발생")
+  void isNotRentedItem() {
+    //given
+    String rentalItemToken = "rentalItemToken";
+    Long currentStationId = 1L;
+    RentalItems mockItem = mock(RentalItems.class);
+    RentalHistory mockHistory = mock(RentalHistory.class);
+
+    given(mockHistory.getRentalItem()).willReturn(mockItem);
+    given(mockItem.isRented()).willReturn(false);
+    given(rentalHistoryRepository.findByItemToken(rentalItemToken)).willReturn(mockHistory);
+
+    //when
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> returnService.getReturnItemInfo(rentalItemToken, currentStationId))
+        .withMessage(ErrorCode.RENTAL_ITEM_NOT_RENTED.getMessage());
+
+    verify(rentalStationRepository, never()).findById(currentStationId);
+  }
+
+  @Test
+  @DisplayName("대여물품 반납 정상 작동")
+  void returnRentalItem() {
+    //given
+    String rentalItemToken = "rentalItemToken";
+    Long returnStationId = 1L;
+
+    RentalItems mockItem = mock(RentalItems.class);
+    RentalHistory mockHistory = mock(RentalHistory.class);
+
+    RentalStations mockStation = mock(RentalStations.class);
+
+    given(mockHistory.getRentalItem()).willReturn(mockItem);
+    given(mockHistory.getStatus()).willReturn(RentalStatus.RENTAL);
+    given(rentalHistoryRepository.findByItemToken(rentalItemToken)).willReturn(mockHistory);
+    given(rentalStationRepository.findById(returnStationId)).willReturn(Optional.of(mockStation));
+
+    //when
+    returnService.returnRentalItem(rentalItemToken, returnStationId);
+
+    //then
+    verify(rentalHistoryRepository).findByItemToken(rentalItemToken);
+    verify(rentalStationRepository).findById(returnStationId);
+    verify(stockLockService).increaseStock(mockItem);
+  }
+
+  @Test
+  @DisplayName("대여내역 상태가 연체일 시 예외 발생")
+  void isOverDueHistory() {
+    //given
+    String rentalItemToken = "rentalItemToken";
+    Long returnStationId = 1L;
+    RentalHistory mockHistory = mock(RentalHistory.class);
+
+    given(mockHistory.getStatus()).willReturn(RentalStatus.OVERDUE);
+    given(rentalHistoryRepository.findByItemToken(rentalItemToken)).willReturn(mockHistory);
+
+    //when then
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> returnService.returnRentalItem(rentalItemToken, returnStationId))
+        .withMessage(ErrorCode.RENTAL_ITEM_OVERDUE.getMessage());
+
+    verify(rentalStationRepository, never()).findById(returnStationId);
+    verify(stockLockService, never()).increaseStock(any(RentalItems.class));
+  }
+
+}

--- a/server/src/test/java/site/bannabe/server/domain/rentals/service/TestRentalStockService.java
+++ b/server/src/test/java/site/bannabe/server/domain/rentals/service/TestRentalStockService.java
@@ -1,4 +1,4 @@
-package site.bannabe.server.domain.payments.service;
+package site.bannabe.server.domain.rentals.service;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -24,6 +24,14 @@ public class TestRentalStockService {
     RentalStations currentStation = rentalItems.getCurrentStation();
     RentalStationItems rentalStationItem = rentalStationItemRepository.findByItemTypeAndStation(rentalItemType, currentStation);
     rentalStationItem.decreaseStock();
+  }
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  void increaseStock(RentalItems rentalItems) {
+    RentalItemTypes rentalItemType = rentalItems.getRentalItemType();
+    RentalStations currentStation = rentalItems.getCurrentStation();
+    RentalStationItems rentalStationItem = rentalStationItemRepository.findByItemTypeAndStation(rentalItemType, currentStation);
+    rentalStationItem.increaseStock();
   }
 
 }

--- a/server/src/test/java/site/bannabe/server/domain/users/service/UserServiceTest.java
+++ b/server/src/test/java/site/bannabe/server/domain/users/service/UserServiceTest.java
@@ -269,7 +269,7 @@ class UserServiceTest {
     //given
     PageRequest pageRequest = PageRequest.of(0, 10);
     int rentalTimeHour = 1;
-    LocalDateTime startTime = LocalDateTime.now().minusHours(1);
+    LocalDateTime startTime = LocalDateTime.now().minusHours(2);
     RentalHistory rentalHistory = RentalHistory.builder()
                                                .status(RentalStatus.RENTAL)
                                                .rentalItem(


### PR DESCRIPTION
## 🔍  요약
- 반납 프로세스 구현
- 연장 / 연체 결제 프로세스 구현

## #️⃣ 연관된 이슈
이슈 x

## 🛠️ 작업 내용
### 반납 물품 데이터 조회 API `/v1/returns/{rentalItemToken}?currentStationId=` `GET`
- RentalItemToken을 사용해 반납할 물품 데이터를 조회합니다.
- 물품이 대여상태가 아니라면 예외를 발생시킵니다.
- 예상 대여시간을 초과했다면 대여상태를 `OVERDUE`로 변경합니다.
  - 추후 FCM을 활용한 앱 푸시알림을 구현해 연체 결제 알림을 추가할 예정입니다.

### 물품 반납 API `/v1/returns/{rentalItemToken}` `POST`
- RentalItemToken을 사용해 물품 반납을 진행합니다.
- 조회한 대여내역이 아직 연체 상태라면 예외를 발생시켜 반납 프로세스를 중단합니다.
- RequestBody로 전달받은 `returnStationId`를 사용해 반납할 스테이션 Entity를 조회한 후, `RentalHistory`와 `RentalItem`에 대해 반납 처리를 진행합니다.
- `RentalStationItems`의 재고를 1 증가시키는 `StockLockService.increaseStock`메서드를 호출합니다.

### 연장 / 연체 결제 프로세스 구현
- `PaymentService.confirmPayment` 메서드에서 결제 승인 이후 `PaymentType`에 맞는 작업을 수행하도록 분기 처리 하였습니다.
- 대여 -> 결제내역 생성, 대여내역 생성 및 대여물품 상태 변경
- 연장 -> 결제 내역 생성, 대여내역 갱신
- 연체 -> 결제 내역 생성, 대여상태 변경


### 대여 API 방어코드 추가
- `RentalService.getRentalItemInfo` 메서드에서 조회한 RentalItem의 상태가 대여 상태라면 예외를 발생시키도록 수정하였습니다.

## 💬 To Other
- 결제 전/후로 연장/연체 결제에 대한 검증이 미흡합니다. 추후 개선 예정입니다.
