### PR TITLE
Feature: 회원정보 조회 API 추가

### DIFF
--- a/server/src/main/java/site/bannabe/server/domain/users/controller/UserController.java
+++ b/server/src/main/java/site/bannabe/server/domain/users/controller/UserController.java
@@ -23,6 +23,7 @@ import site.bannabe.server.domain.users.controller.request.UserChangeProfileImag
 import site.bannabe.server.domain.users.controller.response.S3PreSignedUrlResponse;
 import site.bannabe.server.domain.users.controller.response.UserBookmarkStationsResponse;
 import site.bannabe.server.domain.users.controller.response.UserGetActiveRentalResponse.RentalHistoryResponse;
+import site.bannabe.server.domain.users.controller.response.UserGetSimpleResponse;
 import site.bannabe.server.domain.users.service.UserService;
 import site.bannabe.server.global.security.auth.PrincipalDetails;
 
@@ -32,6 +33,12 @@ import site.bannabe.server.global.security.auth.PrincipalDetails;
 public class UserController {
 
   private final UserService userService;
+
+  @GetMapping("/me")
+  public UserGetSimpleResponse getUserInfo(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+    String entityToken = principalDetails.getEntityToken();
+    return userService.getUserInfo(entityToken);
+  }
 
   @PutMapping("/me/password")
   public void changePassword(@RequestBody @Valid UserChangePasswordRequest changePasswordRequest,

--- a/server/src/main/java/site/bannabe/server/domain/users/controller/response/UserGetSimpleResponse.java
+++ b/server/src/main/java/site/bannabe/server/domain/users/controller/response/UserGetSimpleResponse.java
@@ -1,0 +1,19 @@
+package site.bannabe.server.domain.users.controller.response;
+
+import site.bannabe.server.domain.users.entity.Users;
+
+public record UserGetSimpleResponse(
+    String email,
+    String nickname,
+    String profileImage
+) {
+
+  public static UserGetSimpleResponse of(Users user) {
+    return new UserGetSimpleResponse(
+        user.getEmail(),
+        user.getNickname(),
+        user.getProfileImage()
+    );
+  }
+
+}

--- a/server/src/main/java/site/bannabe/server/domain/users/service/UserService.java
+++ b/server/src/main/java/site/bannabe/server/domain/users/service/UserService.java
@@ -20,6 +20,7 @@ import site.bannabe.server.domain.users.controller.response.S3PreSignedUrlRespon
 import site.bannabe.server.domain.users.controller.response.UserBookmarkStationsResponse;
 import site.bannabe.server.domain.users.controller.response.UserBookmarkStationsResponse.BookmarkStationResponse;
 import site.bannabe.server.domain.users.controller.response.UserGetActiveRentalResponse.RentalHistoryResponse;
+import site.bannabe.server.domain.users.controller.response.UserGetSimpleResponse;
 import site.bannabe.server.domain.users.entity.Users;
 import site.bannabe.server.domain.users.repository.BookmarkStationRepository;
 import site.bannabe.server.domain.users.repository.UserRepository;
@@ -39,6 +40,12 @@ public class UserService {
 
   @Value("${bannabe.default-profile-image}")
   private String defaultProfileImage;
+
+  @Transactional(readOnly = true)
+  public UserGetSimpleResponse getUserInfo(String entityToken) {
+    Users user = userRepository.findByToken(entityToken);
+    return UserGetSimpleResponse.of(user);
+  }
 
   @Transactional
   public void changePassword(String entityToken, UserChangePasswordRequest passwordRequest) {

--- a/server/src/test/java/site/bannabe/server/domain/users/service/UserServiceTest.java
+++ b/server/src/test/java/site/bannabe/server/domain/users/service/UserServiceTest.java
@@ -37,6 +37,7 @@ import site.bannabe.server.domain.users.controller.request.UserChangeProfileImag
 import site.bannabe.server.domain.users.controller.response.UserBookmarkStationsResponse;
 import site.bannabe.server.domain.users.controller.response.UserBookmarkStationsResponse.BookmarkStationResponse;
 import site.bannabe.server.domain.users.controller.response.UserGetActiveRentalResponse.RentalHistoryResponse;
+import site.bannabe.server.domain.users.controller.response.UserGetSimpleResponse;
 import site.bannabe.server.domain.users.entity.Users;
 import site.bannabe.server.domain.users.repository.BookmarkStationRepository;
 import site.bannabe.server.domain.users.repository.UserRepository;
@@ -65,6 +66,30 @@ class UserServiceTest {
   @BeforeEach
   void setUp() {
     ReflectionTestUtils.setField(userService, "defaultProfileImage", "defaultProfileImage.png");
+  }
+
+  @Test
+  @DisplayName("회원정보 조회 성공")
+  void getUserInfo() {
+    //given
+    String entityToken = "entityToken";
+    Users user = Users.builder().nickname("테스트 닉네임").profileImage("프로필 이미지").email("이메일").build();
+
+    given(userRepository.findByToken(entityToken)).willReturn(user);
+
+    //when
+    UserGetSimpleResponse result = userService.getUserInfo(entityToken);
+
+    //then
+    assertThat(result).isNotNull()
+                      .extracting(UserGetSimpleResponse::email,
+                          UserGetSimpleResponse::nickname,
+                          UserGetSimpleResponse::profileImage)
+                      .containsExactly(
+                          user.getEmail(),
+                          user.getNickname(),
+                          user.getProfileImage()
+                      );
   }
 
   @Test


### PR DESCRIPTION
## 🔍  요약
- 회원정보 조회 API 추가

## #️⃣ 연관된 이슈
x

## 🛠️ 작업 내용
### 회원정보 조회 API `/v1/users/me` `GET`
- 유저 식별 토큰을 사용해 마이페이지에 필요한 회원 정보를 조회합니다.
- email, nickname, profileImage 를 응답합니다.

## 💬 To Other
