### PR TITLE
Fix: Swagger Interceptor 추가

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches-ignore:
       - main
-      - develop
 
 jobs:
   build:

--- a/server/src/main/resources/static/swagger/swagger-initializer.js
+++ b/server/src/main/resources/static/swagger/swagger-initializer.js
@@ -13,7 +13,21 @@ window.onload = function () {
     plugins: [
       SwaggerUIBundle.plugins.DownloadUrl
     ],
-    layout: "StandaloneLayout"
+    layout: "StandaloneLayout",
+    requestInterceptor: function (req) {
+      const token = sessionStorage.getItem("accessToken");
+      if (token) {
+        req.headers["Authorization"] = "Bearer " + token;
+      }
+      return req;
+    },
+
+    responseInterceptor: function (res) {
+      if (res.url.includes('/v1/auth/login') && res.body?.data) {
+        sessionStorage.setItem('accessToken', res.body.data.accessToken);
+      }
+      return res;
+    }
   });
 
   //</editor-fold>


### PR DESCRIPTION
## 🔍  요약
- Swagger Interceptor 추가
- GitHubActions Push workflow Target 수정

## #️⃣ 연관된 이슈
이슈 x

## 🛠️ 작업 내용
### 1. Swagger Interceptor 추가
- `swagger-initializer.js`에 request, response Interceptor를 추가하였습니다.
- 요청시 sessionStorage에 저장된 AccessToken을 `Authorization` 헤더로 첨부합니다.
- `/v1/auth/login` API 호출시 응답으로 온 AccessToken을 sessionStorage에 저장합니다.

### 2. Push Workflow Target Branch 수정
- Gradle 캐시를 위해선 `main` `develop`에서 build가 진행되어야합니다.
- 현재는 `develop`브랜치에서 build된 적이 없어 캐시 miss가 지속적으로 발생합니다.
- 이를 해결하기 위해 `branches-ignore` 에서 `develop` 브랜치를 제거하였습니다.
## 💬 To Other
.
