### PR TITLE
Chore: Jacoco 추가

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -181,8 +181,8 @@ tasks.named('jacocoTestReport', JacocoReport) {
         html.required.set(true)
         xml.required.set(true)
 
-        xml.destination(file(layout.buildDirectory.file("/jacoco/jacoco.xml")))
-        html.destination(file(layout.buildDirectory.dir("/jacoco/html")))
+        xml.destination(file(layout.buildDirectory.file("jacoco/jacoco.xml")))
+        html.destination(file(layout.buildDirectory.dir("jacoco/html")))
     }
 
     excludedClassFilesForReport(classDirectories)

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
     id 'com.epages.restdocs-api-spec' version '0.19.0'
     id 'com.github.node-gradle.node' version '7.0.1'
+    id 'jacoco'
 }
 
 group = 'site.bannabe'
@@ -13,6 +14,10 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
     }
+}
+
+jacoco {
+    toolVersion = '0.8.11'
 }
 
 node {
@@ -117,7 +122,7 @@ tasks.named('test') {
     useJUnitPlatform()
     //OpenJDK 64-bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended 방지
     jvmArgs '-Xshare:off'
-    finalizedBy 'copyOasToSwagger'
+    finalizedBy 'copyOasToSwagger', 'jacocoTestReport'
 }
 
 tasks.named('build') {
@@ -158,4 +163,77 @@ tasks.register('tailwindCss', NpmTask) {
 tasks.named('processResources') {
     dependsOn 'tailwindCss'
 }
+
+gradle.taskGraph.whenReady { taskGraph ->
+    if (gradle.startParameter.taskNames == ['test']) {
+        ['nodeSetup', 'npmSetup', 'npmInstall', 'tailwindCss', 'processResources'].each { taskName ->
+            tasks.named(taskName).configure { enabled = false }
+        }
+    }
+}
 /*TailwindCss Config*/
+
+/*Jacoco Config*/
+tasks.named('jacocoTestReport', JacocoReport) {
+    dependsOn test
+
+    reports {
+        html.required.set(true)
+        xml.required.set(true)
+
+        xml.destination(file(layout.buildDirectory.file("/jacoco/jacoco.xml")))
+        html.destination(file(layout.buildDirectory.dir("/jacoco/html")))
+    }
+
+    excludedClassFilesForReport(classDirectories)
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+tasks.named('jacocoTestCoverageVerification', JacocoCoverageVerification) {
+    excludedClassFilesForReport(classDirectories)
+
+    violationRules {
+        rule {
+            element = 'CLASS'
+            enabled = true
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                // minimum = 0.8
+            }
+
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                // minimum = 0.8
+            }
+        }
+    }
+}
+
+private excludedClassFilesForReport(classDirectories) {
+    classDirectories.setFrom(
+            files(classDirectories.files.collect {
+                fileTree(dir: it, exclude: [
+                        '**/entity/**',
+                        '**/request/**',
+                        '**/response/**',
+                        '**/config/**',
+                        '**/*Application*',
+                        '**/converter/**',
+                        '**/type/**',
+                        '**/redis/**',
+                        '**/api/**',
+                        '**/security/**',
+                        '**/advice/**',
+                        '**/utils/**',
+                        '**/JWTVerificationStatus*',
+                        '**/OAuth2UserInfo*',
+                        '**/PaymentViewController*',
+                        '**/PaymentTestController*'
+                ])
+            })
+    )
+}
+/*Jacoco Config*/

--- a/server/src/main/java/site/bannabe/server/domain/users/controller/UserController.java
+++ b/server/src/main/java/site/bannabe/server/domain/users/controller/UserController.java
@@ -54,6 +54,12 @@ public class UserController {
     userService.changeProfileImage(entityToken, changeProfileImageRequest);
   }
 
+  @PatchMapping("/me/profile-image/default")
+  public void changeProfileImageToDefault(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+    String entityToken = principalDetails.getEntityToken();
+    userService.changeProfileImageToDefault(entityToken);
+  }
+
   @PatchMapping("/me/nickname")
   public void changeNickname(@RequestBody @Valid UserChangeNicknameRequest changeNicknameRequest,
       @AuthenticationPrincipal PrincipalDetails principalDetails) {

--- a/server/src/main/java/site/bannabe/server/domain/users/controller/response/UserGetSimpleResponse.java
+++ b/server/src/main/java/site/bannabe/server/domain/users/controller/response/UserGetSimpleResponse.java
@@ -5,14 +5,16 @@ import site.bannabe.server.domain.users.entity.Users;
 public record UserGetSimpleResponse(
     String email,
     String nickname,
-    String profileImage
+    String profileImage,
+    Boolean isDefaultProfileImage
 ) {
 
-  public static UserGetSimpleResponse of(Users user) {
+  public static UserGetSimpleResponse of(Users user, String defaultProfileImage) {
     return new UserGetSimpleResponse(
         user.getEmail(),
         user.getNickname(),
-        user.getProfileImage()
+        user.getProfileImage(),
+        user.getProfileImage().equals(defaultProfileImage)
     );
   }
 

--- a/server/src/main/java/site/bannabe/server/domain/users/service/UserService.java
+++ b/server/src/main/java/site/bannabe/server/domain/users/service/UserService.java
@@ -45,7 +45,7 @@ public class UserService {
   @Transactional(readOnly = true)
   public UserGetSimpleResponse getUserInfo(String entityToken) {
     Users user = userRepository.findByToken(entityToken);
-    return UserGetSimpleResponse.of(user);
+    return UserGetSimpleResponse.of(user, defaultProfileImage);
   }
 
   @Transactional
@@ -87,6 +87,16 @@ public class UserService {
     }
 
     user.changeProfileImage(newProfileImage);
+  }
+
+  @Transactional
+  public void changeProfileImageToDefault(String entityToken) {
+    Users user = userRepository.findByToken(entityToken);
+    if (user.getProfileImage().equals(defaultProfileImage)) {
+      throw new BannabeServiceException(ErrorCode.PROFILE_IMAGE_ALREADY_DEFAULT);
+    }
+    s3Service.removeProfileImage(user.getProfileImage());
+    user.changeProfileImage(defaultProfileImage);
   }
 
   public S3PreSignedUrlResponse getPreSignedUrl(String extension) {

--- a/server/src/main/java/site/bannabe/server/global/exceptions/ErrorCode.java
+++ b/server/src/main/java/site/bannabe/server/global/exceptions/ErrorCode.java
@@ -55,6 +55,7 @@ public enum ErrorCode {
   ORDER_INFO_EXISTS(HttpStatus.CONFLICT, "해당 대여물품에 대한 주문 정보가 이미 존재합니다."),
   RENTAL_ITEM_STOCK_EMPTY(HttpStatus.CONFLICT, "대여물품 재고가 부족합니다."),
   RENTAL_ITEM_ALREADY_RENTED(HttpStatus.CONFLICT, "해당 물품은 이미 대여 중 입니다."),
+  PROFILE_IMAGE_ALREADY_DEFAULT(HttpStatus.CONFLICT, "이미 기본 프로필 이미지입니다."),
 
   // 500 INTERNAL_SERVER_ERROR
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류입니다. 관리자에게 문의하세요."),

--- a/server/src/main/resources/static/swagger/openapi3.yaml
+++ b/server/src/main/resources/static/swagger/openapi3.yaml
@@ -145,8 +145,8 @@ paths:
               examples:
                 auth_controller_test/login_success:
                   value: "{\r\n  \"success\" : true,\r\n  \"message\" : \"로그인 성공\"\
-                    ,\r\n  \"data\" : {\r\n    \"accessToken\" : \"eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJVU1Jfc2tsTUV2TmtWaCIsIlJPTEUiOiJST0xFX1VTRVIiLCJpYXQiOjE3NDI2MTc5NzMsImV4cCI6MTc0MjYxOTc3M30.Uk-hk1oNLfF4H0KCbGYW3ZheMhhOCvdZUGGlF8wUCUbPmqP18MIr7i0n-wLM5fZQVJmfWPAuCczynT3dbBEWzQ\"\
-                    ,\r\n    \"refreshToken\" : \"eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJVU1Jfc2tsTUV2TmtWaCIsIlJPTEUiOiJST0xFX1VTRVIiLCJpYXQiOjE3NDI2MTc5NzMsImV4cCI6MTc0MzIyMjc3M30.lYfVlKeiyqftqhdTueZ7XbaAykEHyMbRq8gc34MfTzKgUp5pA1F6S_X-7tEu_79Wvet_VAgD2SXVA3zX1DYrbA\"\
+                    ,\r\n  \"data\" : {\r\n    \"accessToken\" : \"eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJVU1JfRThsMnMxYUkwZiIsIlJPTEUiOiJST0xFX1VTRVIiLCJpYXQiOjE3NDMxNjA2NzYsImV4cCI6MTc0MzE2MjQ3Nn0.htvAHk8GPn89uaSLG0SJm_cbmt4Z9kWOGO8SzFUfOr311Ct0qtfMfcKJUuzkbLqYBm4RXLHd76e-8G31Rs7NfQ\"\
+                    ,\r\n    \"refreshToken\" : \"eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJVU1JfRThsMnMxYUkwZiIsIlJPTEUiOiJST0xFX1VTRVIiLCJpYXQiOjE3NDMxNjA2NzYsImV4cCI6MTc0Mzc2NTQ3Nn0.XlqCMeIRWdcORUMvCHUitBzANJdhwEO3z-QLrH__S462UY1MiFuPHo_NiocPtrrMky78aht-BzVFbtqs9xSbYQ\"\
                     \r\n  }\r\n}"
   /v1/auth/logout:
     post:
@@ -162,7 +162,7 @@ paths:
               $ref: "#/components/schemas/v1-stations486549215"
             examples:
               auth_controller_test/logout_success:
-                value: "{\r\n  \"refreshToken\" : \"eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJVU1JfM3YzNDFrUWNpZCIsIlJPTEUiOiJST0xFX1VTRVIiLCJpYXQiOjE3NDI2MTc5NzAsImV4cCI6MTc0MzIyMjc3MH0.yiwWeejqwbFu9nzhOtX8shQbKrb1TzitH0wJITnrrAsS0gcNSTHieZixCIiJDw5B9lrA60PAfvGiLzCU6f6iMw\"\
+                value: "{\r\n  \"refreshToken\" : \"eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJVU1JfRFNaMkFYT3lPWSIsIlJPTEUiOiJST0xFX1VTRVIiLCJpYXQiOjE3NDMxNjA2NzQsImV4cCI6MTc0Mzc2NTQ3NH0.p9B7a9Ejug8mVgna8FKg_XH4e3TCMTQIflBb4vT4JSjsXU5QMMyOEjNPUtR-3Hzks3gT412tldKnS-FF0O8f6Q\"\
                   \r\n}"
       responses:
         "200":
@@ -218,7 +218,7 @@ paths:
               $ref: "#/components/schemas/v1-stations486549215"
             examples:
               auth_controller_test/rest_password:
-                value: "{\r\n  \"authCode\" : \"loMMWu\",\r\n  \"email\" : \"test@test.com\"\
+                value: "{\r\n  \"authCode\" : \"4koKGg\",\r\n  \"email\" : \"test@test.com\"\
                   ,\r\n  \"newPassword\" : \"5678\",\r\n  \"newPasswordConfirm\" :\
                   \ \"5678\"\r\n}"
       responses:
@@ -273,7 +273,7 @@ paths:
             examples:
               auth_controller_test/verify_auth_code:
                 value: "{\r\n  \"email\" : \"test@test.com\",\r\n  \"authCode\" :\
-                  \ \"pWgfCG\"\r\n}"
+                  \ \"kX1V3A\"\r\n}"
       responses:
         "200":
           description: "200"
@@ -299,7 +299,7 @@ paths:
               $ref: "#/components/schemas/v1-stations486549215"
             examples:
               payment_controller_test/calculate_amount:
-                value: "{\r\n  \"rentalItemToken\" : \"RI_OA90yCrYOb\",\r\n  \"rentalTime\"\
+                value: "{\r\n  \"rentalItemToken\" : \"RI_iKlxIVa9zl\",\r\n  \"rentalTime\"\
                   \ : 2\r\n}"
       responses:
         "200":
@@ -312,7 +312,7 @@ paths:
                 payment_controller_test/calculate_amount:
                   value: "{\r\n  \"success\" : true,\r\n  \"message\" : \"요청이 성공적으\
                     로 처리되었습니다.\",\r\n  \"data\" : {\r\n    \"rentalItemToken\" : \"\
-                    RI_OA90yCrYOb\",\r\n    \"pricePerHour\" : 1000,\r\n    \"rentalTime\"\
+                    RI_iKlxIVa9zl\",\r\n    \"pricePerHour\" : 1000,\r\n    \"rentalTime\"\
                     \ : 2,\r\n    \"amount\" : 2000\r\n  }\r\n}"
       security:
       - bearerAuthJWT: []
@@ -364,7 +364,7 @@ paths:
                 payment_controller_test/confirm_payment:
                   value: "{\r\n  \"success\" : true,\r\n  \"message\" : \"요청이 성공적으\
                     로 처리되었습니다.\",\r\n  \"data\" : {\r\n    \"rentalHistoryToken\"\
-                    \ : \"RH_ZKfnL4o3Vt\"\r\n  }\r\n}"
+                    \ : \"RH_bSYWis4nPS\"\r\n  }\r\n}"
       security:
       - bearerAuthJWT: []
   /v1/rentals/{rentalItemToken}:
@@ -423,8 +423,8 @@ paths:
                     로 처리되었습니다.\",\r\n  \"data\" : {\r\n    \"rentalItemName\" : \"\
                     65W 충전기\",\r\n    \"rentalHistory\" : {\r\n      \"status\" :\
                     \ \"RENTAL\",\r\n      \"rentalTime\" : 1,\r\n      \"startTime\"\
-                    \ : \"2025-03-22T13:32:33\",\r\n      \"expectedReturnTime\" :\
-                    \ \"2025-03-22T14:32:33\"\r\n    },\r\n    \"rentalStation\" :\
+                    \ : \"2025-03-28T20:17:34\",\r\n      \"expectedReturnTime\" :\
+                    \ \"2025-03-28T21:17:34\"\r\n    },\r\n    \"rentalStation\" :\
                     \ {\r\n      \"rentalStationName\" : \"대여 스테이션\",\r\n      \"\
                     currentStationName\" : \"반납 스테이션\"\r\n    }\r\n  }\r\n}"
       security:
@@ -513,7 +513,8 @@ paths:
                   value: "{\r\n  \"success\" : true,\r\n  \"message\" : \"요청이 성공적으\
                     로 처리되었습니다.\",\r\n  \"data\" : {\r\n    \"email\" : \"test@test.com\"\
                     ,\r\n    \"nickname\" : \"TestUser\",\r\n    \"profileImage\"\
-                    \ : \"https://test.com/test.jpg\"\r\n  }\r\n}"
+                    \ : \"https://test.com/test.jpg\",\r\n    \"isDefaultProfileImage\"\
+                    \ : false\r\n  }\r\n}"
       security:
       - bearerAuthJWT: []
   /v1/auth/token/refresh:
@@ -530,7 +531,7 @@ paths:
               $ref: "#/components/schemas/v1-stations486549215"
             examples:
               auth_controller_test/refresh_jwt:
-                value: "{\r\n  \"refreshToken\" : \"eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJVU1JfcmFQQ3dIeU5XQSIsIlJPTEUiOiJST0xFX1VTRVIiLCJpYXQiOjE3NDI2MTc5NzEsImV4cCI6MTc0MzIyMjc3MX0.RXMOy-s8SYsMGUlZZ7Y62FxfaviA6JAdAt6e4KXRSyEAK_g2GJUJPi2B2Hf2P-NkoBrWSlunA1wjTWwa-yQWCQ\"\
+                value: "{\r\n  \"refreshToken\" : \"eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJVU1JfeUhIVjltUVBzeiIsIlJPTEUiOiJST0xFX1VTRVIiLCJpYXQiOjE3NDMxNjA2NzQsImV4cCI6MTc0Mzc2NTQ3NH0.aiQobyR4nql2u7ZWuzVwoWQAo6agXH0f5cD90eQ8DsZqqPF05jXDcdZnN2ovXMsfiQRjFxShNiV6KIW8Esxn8g\"\
                   \r\n}"
       responses:
         "200":
@@ -542,8 +543,8 @@ paths:
               examples:
                 auth_controller_test/refresh_jwt:
                   value: "{\r\n  \"success\" : true,\r\n  \"message\" : \"요청이 성공적으\
-                    로 처리되었습니다.\",\r\n  \"data\" : {\r\n    \"accessToken\" : \"eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJVU1JfcmFQQ3dIeU5XQSIsIlJPTEUiOiJST0xFX1VTRVIiLCJpYXQiOjE3NDI2MTc5NzEsImV4cCI6MTc0MjYxOTc3MX0.DMmKO5Iq3uFRaD2ApkjtdTsRlZOnWd94CczS5l4nq3K_NBmd18E9FEw05S8LzEhwk-bNKvbxioooR0kBnXZvSw\"\
-                    ,\r\n    \"refreshToken\" : \"eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJVU1JfcmFQQ3dIeU5XQSIsIlJPTEUiOiJST0xFX1VTRVIiLCJpYXQiOjE3NDI2MTc5NzEsImV4cCI6MTc0MzIyMjc3MX0.RXMOy-s8SYsMGUlZZ7Y62FxfaviA6JAdAt6e4KXRSyEAK_g2GJUJPi2B2Hf2P-NkoBrWSlunA1wjTWwa-yQWCQ\"\
+                    로 처리되었습니다.\",\r\n  \"data\" : {\r\n    \"accessToken\" : \"eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJVU1JfeUhIVjltUVBzeiIsIlJPTEUiOiJST0xFX1VTRVIiLCJpYXQiOjE3NDMxNjA2NzQsImV4cCI6MTc0MzE2MjQ3NH0.4XzNgtJfllCgCJqIQTD_K0-v3EDhBidQGrFA73VPxTtUDzWE4w7QCZKe9VvGKis6DUHkj-eDN2VRx1k1aGu7pA\"\
+                    ,\r\n    \"refreshToken\" : \"eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJVU1JfeUhIVjltUVBzeiIsIlJPTEUiOiJST0xFX1VTRVIiLCJpYXQiOjE3NDMxNjA2NzQsImV4cCI6MTc0Mzc2NTQ3NH0.aiQobyR4nql2u7ZWuzVwoWQAo6agXH0f5cD90eQ8DsZqqPF05jXDcdZnN2ovXMsfiQRjFxShNiV6KIW8Esxn8g\"\
                     \r\n  }\r\n}"
   /v1/oauth2/login/{provider}:
     post:
@@ -578,8 +579,8 @@ paths:
               examples:
                 o_auth2_controller_test/kakao_login_success:
                   value: "{\r\n  \"success\" : true,\r\n  \"message\" : \"요청이 성공적으\
-                    로 처리되었습니다.\",\r\n  \"data\" : {\r\n    \"accessToken\" : \"eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwiUk9MRSI6IlJPTEVfVVNFUiIsImlhdCI6MTc0MjYxNzk3NywiZXhwIjoxNzQyNjE5Nzc3fQ.TW_UofjJGp8Ngmg_wCd-Y-ZuHQ3sETBcu5wrCVwVBLdgB_ance6yAPCb_4a1AIxFBjAoZ0nqXGOOVp_1br2oBg\"\
-                    ,\r\n    \"refreshToken\" : \"eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwiUk9MRSI6IlJPTEVfVVNFUiIsImlhdCI6MTc0MjYxNzk3NywiZXhwIjoxNzQzMjIyNzc3fQ.uKYYCP-dC5g2GPRncuQDrtsSP85xDfOeoOdUCJhh3a8aAejc79TpU4gf7858aQuqnjHRIkpLx7jP-vguL6xRDQ\"\
+                    로 처리되었습니다.\",\r\n  \"data\" : {\r\n    \"accessToken\" : \"eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwiUk9MRSI6IlJPTEVfVVNFUiIsImlhdCI6MTc0MzE2MDY4MCwiZXhwIjoxNzQzMTYyNDgwfQ.YtBq69X3-WbcaRYfCs8voSPHbC4YxitEo_B8xs_8z73alQMCtebHz9BH-trSHeAtunoy8jqLcfXK0coW1fb12Q\"\
+                    ,\r\n    \"refreshToken\" : \"eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwiUk9MRSI6IlJPTEVfVVNFUiIsImlhdCI6MTc0MzE2MDY4MCwiZXhwIjoxNzQzNzY1NDgwfQ.tfG_xQT5Rc_WlzYaBNI5RoiBhDR6vAb0EuLIPkgdsSWCc5ANODATSjOS0WuGzvhbEFGsnH6-RG1mUKLmQ5XuFg\"\
                     \r\n  }\r\n}"
   /v1/rentals/success/{rentalHistoryToken}:
     get:
@@ -742,45 +743,45 @@ paths:
                   value: "{\r\n  \"success\" : true,\r\n  \"message\" : \"요청이 성공적으\
                     로 처리되었습니다.\",\r\n  \"data\" : {\r\n    \"content\" : [ {\r\n \
                     \     \"name\" : \"65W충전기\",\r\n      \"status\" : \"대여중\",\r\n\
-                    \      \"rentalTimeHour\" : 1,\r\n      \"startTime\" : \"2025-03-22T14:33:02\"\
-                    ,\r\n      \"expectedReturnTime\" : \"2025-03-22T15:33:02\",\r\
-                    \n      \"token\" : \"RH_JLSFumM1xH\"\r\n    }, {\r\n      \"\
+                    \      \"rentalTimeHour\" : 1,\r\n      \"startTime\" : \"2025-03-28T21:18:06\"\
+                    ,\r\n      \"expectedReturnTime\" : \"2025-03-28T22:18:06\",\r\
+                    \n      \"token\" : \"RH_2vFDnCaDKT\"\r\n    }, {\r\n      \"\
                     name\" : \"65W충전기\",\r\n      \"status\" : \"대여중\",\r\n      \"\
-                    rentalTimeHour\" : 1,\r\n      \"startTime\" : \"2025-03-22T14:33:02\"\
-                    ,\r\n      \"expectedReturnTime\" : \"2025-03-22T15:33:02\",\r\
-                    \n      \"token\" : \"RH_xUB1hG8srO\"\r\n    }, {\r\n      \"\
+                    rentalTimeHour\" : 1,\r\n      \"startTime\" : \"2025-03-28T21:18:06\"\
+                    ,\r\n      \"expectedReturnTime\" : \"2025-03-28T22:18:06\",\r\
+                    \n      \"token\" : \"RH_onSunxzjTa\"\r\n    }, {\r\n      \"\
                     name\" : \"65W충전기\",\r\n      \"status\" : \"반납\",\r\n      \"\
-                    rentalTimeHour\" : 1,\r\n      \"startTime\" : \"2025-03-21T13:33:02\"\
-                    ,\r\n      \"expectedReturnTime\" : \"2025-03-21T14:33:02\",\r\
-                    \n      \"token\" : \"RH_TlIAQvlOWb\"\r\n    }, {\r\n      \"\
+                    rentalTimeHour\" : 1,\r\n      \"startTime\" : \"2025-03-27T20:18:06\"\
+                    ,\r\n      \"expectedReturnTime\" : \"2025-03-27T21:18:06\",\r\
+                    \n      \"token\" : \"RH_pCxonF9BYv\"\r\n    }, {\r\n      \"\
                     name\" : \"65W충전기\",\r\n      \"status\" : \"반납\",\r\n      \"\
-                    rentalTimeHour\" : 1,\r\n      \"startTime\" : \"2025-03-20T13:33:02\"\
-                    ,\r\n      \"expectedReturnTime\" : \"2025-03-20T14:33:02\",\r\
-                    \n      \"token\" : \"RH_3XBnFnyUX3\"\r\n    }, {\r\n      \"\
+                    rentalTimeHour\" : 1,\r\n      \"startTime\" : \"2025-03-26T20:18:06\"\
+                    ,\r\n      \"expectedReturnTime\" : \"2025-03-26T21:18:06\",\r\
+                    \n      \"token\" : \"RH_V3ZhHy4z2J\"\r\n    }, {\r\n      \"\
                     name\" : \"65W충전기\",\r\n      \"status\" : \"반납\",\r\n      \"\
-                    rentalTimeHour\" : 1,\r\n      \"startTime\" : \"2025-03-19T13:33:02\"\
-                    ,\r\n      \"expectedReturnTime\" : \"2025-03-19T14:33:02\",\r\
-                    \n      \"token\" : \"RH_HYRhPou9FA\"\r\n    }, {\r\n      \"\
+                    rentalTimeHour\" : 1,\r\n      \"startTime\" : \"2025-03-25T20:18:06\"\
+                    ,\r\n      \"expectedReturnTime\" : \"2025-03-25T21:18:06\",\r\
+                    \n      \"token\" : \"RH_gSIVfidbwm\"\r\n    }, {\r\n      \"\
                     name\" : \"65W충전기\",\r\n      \"status\" : \"반납\",\r\n      \"\
-                    rentalTimeHour\" : 1,\r\n      \"startTime\" : \"2025-03-18T13:33:02\"\
-                    ,\r\n      \"expectedReturnTime\" : \"2025-03-18T14:33:02\",\r\
-                    \n      \"token\" : \"RH_LmZvgSbxyD\"\r\n    }, {\r\n      \"\
+                    rentalTimeHour\" : 1,\r\n      \"startTime\" : \"2025-03-24T20:18:06\"\
+                    ,\r\n      \"expectedReturnTime\" : \"2025-03-24T21:18:06\",\r\
+                    \n      \"token\" : \"RH_4QagpykCj5\"\r\n    }, {\r\n      \"\
                     name\" : \"65W충전기\",\r\n      \"status\" : \"반납\",\r\n      \"\
-                    rentalTimeHour\" : 1,\r\n      \"startTime\" : \"2025-03-17T13:33:02\"\
-                    ,\r\n      \"expectedReturnTime\" : \"2025-03-17T14:33:02\",\r\
-                    \n      \"token\" : \"RH_FzvDqjNIrg\"\r\n    }, {\r\n      \"\
+                    rentalTimeHour\" : 1,\r\n      \"startTime\" : \"2025-03-23T20:18:06\"\
+                    ,\r\n      \"expectedReturnTime\" : \"2025-03-23T21:18:06\",\r\
+                    \n      \"token\" : \"RH_mchI4WnMds\"\r\n    }, {\r\n      \"\
                     name\" : \"65W충전기\",\r\n      \"status\" : \"반납\",\r\n      \"\
-                    rentalTimeHour\" : 1,\r\n      \"startTime\" : \"2025-03-16T13:33:02\"\
-                    ,\r\n      \"expectedReturnTime\" : \"2025-03-16T14:33:02\",\r\
-                    \n      \"token\" : \"RH_f2JcNRmjBF\"\r\n    }, {\r\n      \"\
+                    rentalTimeHour\" : 1,\r\n      \"startTime\" : \"2025-03-22T20:18:06\"\
+                    ,\r\n      \"expectedReturnTime\" : \"2025-03-22T21:18:06\",\r\
+                    \n      \"token\" : \"RH_DJbGgtJUUY\"\r\n    }, {\r\n      \"\
                     name\" : \"65W충전기\",\r\n      \"status\" : \"반납\",\r\n      \"\
-                    rentalTimeHour\" : 1,\r\n      \"startTime\" : \"2025-03-15T13:33:02\"\
-                    ,\r\n      \"expectedReturnTime\" : \"2025-03-15T14:33:02\",\r\
-                    \n      \"token\" : \"RH_NzfURzrlmf\"\r\n    }, {\r\n      \"\
+                    rentalTimeHour\" : 1,\r\n      \"startTime\" : \"2025-03-21T20:18:06\"\
+                    ,\r\n      \"expectedReturnTime\" : \"2025-03-21T21:18:06\",\r\
+                    \n      \"token\" : \"RH_m6y0T8b9vp\"\r\n    }, {\r\n      \"\
                     name\" : \"65W충전기\",\r\n      \"status\" : \"반납\",\r\n      \"\
-                    rentalTimeHour\" : 1,\r\n      \"startTime\" : \"2025-03-14T13:33:02\"\
-                    ,\r\n      \"expectedReturnTime\" : \"2025-03-14T14:33:02\",\r\
-                    \n      \"token\" : \"RH_ZsUbCz1LpL\"\r\n    } ],\r\n    \"page\"\
+                    rentalTimeHour\" : 1,\r\n      \"startTime\" : \"2025-03-20T20:18:06\"\
+                    ,\r\n      \"expectedReturnTime\" : \"2025-03-20T21:18:06\",\r\
+                    \n      \"token\" : \"RH_NXF2Duzscr\"\r\n    } ],\r\n    \"page\"\
                     \ : {\r\n      \"size\" : 10,\r\n      \"number\" : 0,\r\n   \
                     \   \"totalElements\" : 20,\r\n      \"totalPages\" : 2\r\n  \
                     \  }\r\n  }\r\n}"
@@ -820,6 +821,26 @@ paths:
                     ,\r\n    \"image\" : \"test-image.png\",\r\n    \"category\" :\
                     \ \"CHARGER\",\r\n    \"description\" : \"테스트 설명\",\r\n    \"\
                     price\" : 1000,\r\n    \"stock\" : 10\r\n  }\r\n}"
+  /v1/users/me/profile-image/default:
+    patch:
+      tags:
+      - UserController
+      summary: 프로필 이미지 초기화 API
+      description: 프로필 이미지 초기화 API
+      operationId: user_controller_test/change_profile_image_to_default
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/v1-stations486549215"
+              examples:
+                user_controller_test/change_profile_image_to_default:
+                  value: "{\r\n  \"success\" : true,\r\n  \"message\" : \"요청이 성공적으\
+                    로 처리되었습니다.\",\r\n  \"data\" : { }\r\n}"
+      security:
+      - bearerAuthJWT: []
   /v1/users/me/profile-image/pre-signed:
     get:
       tags:
@@ -860,13 +881,13 @@ paths:
                   value: "{\r\n  \"success\" : true,\r\n  \"message\" : \"요청이 성공적으\
                     로 처리되었습니다.\",\r\n  \"data\" : {\r\n    \"rentals\" : [ {\r\n \
                     \     \"name\" : \"65W충전기\",\r\n      \"status\" : \"대여중\",\r\n\
-                    \      \"rentalTimeHour\" : 1,\r\n      \"startTime\" : \"2025-03-22T14:33:02\"\
-                    ,\r\n      \"expectedReturnTime\" : \"2025-03-22T15:33:02\",\r\
-                    \n      \"token\" : \"RH_sey0gF4GLa\"\r\n    }, {\r\n      \"\
+                    \      \"rentalTimeHour\" : 1,\r\n      \"startTime\" : \"2025-03-28T21:18:05\"\
+                    ,\r\n      \"expectedReturnTime\" : \"2025-03-28T22:18:05\",\r\
+                    \n      \"token\" : \"RH_C4SeqTZYsR\"\r\n    }, {\r\n      \"\
                     name\" : \"65W충전기\",\r\n      \"status\" : \"대여중\",\r\n      \"\
-                    rentalTimeHour\" : 1,\r\n      \"startTime\" : \"2025-03-22T14:33:02\"\
-                    ,\r\n      \"expectedReturnTime\" : \"2025-03-22T15:33:02\",\r\
-                    \n      \"token\" : \"RH_O8WFwhk2xf\"\r\n    } ]\r\n  }\r\n}"
+                    rentalTimeHour\" : 1,\r\n      \"startTime\" : \"2025-03-28T21:18:05\"\
+                    ,\r\n      \"expectedReturnTime\" : \"2025-03-28T22:18:05\",\r\
+                    \n      \"token\" : \"RH_RpJ85rCOYd\"\r\n    } ]\r\n  }\r\n}"
       security:
       - bearerAuthJWT: []
   /v1/users/me/stations/bookmark:

--- a/server/src/test/java/site/bannabe/server/domain/users/controller/UserControllerTest.java
+++ b/server/src/test/java/site/bannabe/server/domain/users/controller/UserControllerTest.java
@@ -210,6 +210,25 @@ class UserControllerTest extends AbstractIntegrationTest {
   }
 
   @Test
+  @DisplayName("기본 프로필 이미지로 변경 성공시 200 응답")
+  void changeProfileImageToDefault() {
+    //given
+    willDoNothing().given(s3Service).removeProfileImage(user.getProfileImage());
+
+    //when then
+    given(this.spec)
+        .filter(
+            createChangeProfileImageToDefaultDocument()
+        ).log().all()
+        .contentType(JSON)
+        .header(AUTHORIZATION, "Bearer " + accessToken)
+        .when()
+        .patch("/v1/users/me/profile-image/default")
+        .then().log().all()
+        .statusCode(HttpStatus.OK.value());
+  }
+
+  @Test
   @DisplayName("S3 preSignedUrl 조회")
   void getPreSignedUrl() {
     //given
@@ -369,7 +388,8 @@ class UserControllerTest extends AbstractIntegrationTest {
             fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
             fieldWithPath("data.email").type(JsonFieldType.STRING).description("이메일"),
             fieldWithPath("data.nickname").type(JsonFieldType.STRING).description("닉네임"),
-            fieldWithPath("data.profileImage").type(JsonFieldType.STRING).description("프로필 이미지")
+            fieldWithPath("data.profileImage").type(JsonFieldType.STRING).description("프로필 이미지"),
+            fieldWithPath("data.isDefaultProfileImage").type(JsonFieldType.BOOLEAN).description("기본 프로필 이미지 여부")
         )
     );
   }
@@ -430,6 +450,24 @@ class UserControllerTest extends AbstractIntegrationTest {
         ),
         requestFields(
             fieldWithPath("imageUrl").type(JsonFieldType.STRING).description("변경할 프로필 이미지 URL")
+        ),
+        responseFields(
+            fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+            fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
+            fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터")
+        )
+    );
+  }
+
+  private RestDocumentationFilter createChangeProfileImageToDefaultDocument() {
+    return document(DEFAULT_RESTDOC_PATH,
+        resource(ResourceSnippetParameters.builder()
+                                          .tag(this.getClass().getSimpleName().replace("Test", ""))
+                                          .summary("프로필 이미지 초기화 API")
+                                          .build()
+        ),
+        requestHeaders(
+            headerWithName(AUTHORIZATION).description("Bearer Token")
         ),
         responseFields(
             fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),

--- a/server/src/test/java/site/bannabe/server/domain/users/service/UserServiceTest.java
+++ b/server/src/test/java/site/bannabe/server/domain/users/service/UserServiceTest.java
@@ -394,4 +394,35 @@ class UserServiceTest {
         .withMessage(ErrorCode.BOOKMARK_NOT_EXIST.getMessage());
   }
 
+  @Test
+  @DisplayName("프로필 이미지를 기본 이미지로 변경")
+  void changeProfileImageToDefault() {
+    //given
+    String currentProfileImage = "currentProfileImage";
+    Users user = Users.builder().email(EMAIL).profileImage(currentProfileImage).build();
+    given(userRepository.findByToken(entityToken)).willReturn(user);
+
+    //when
+    userService.changeProfileImageToDefault(entityToken);
+
+    //then
+    assertThat(user.getProfileImage()).isEqualTo("defaultProfileImage.png");
+    verify(s3Service).removeProfileImage(currentProfileImage);
+  }
+
+  @Test
+  @DisplayName("프로필 이미지를 기본 이미지로 변경 시, 이미 기본 이미지라면 예외 발생")
+  void alreadyDefaultProfileImage() {
+    //given
+    Users user = Users.builder().profileImage("defaultProfileImage.png").build();
+    given(userRepository.findByToken(entityToken)).willReturn(user);
+
+    //when then
+    assertThatExceptionOfType(BannabeServiceException.class)
+        .isThrownBy(() -> userService.changeProfileImageToDefault(entityToken))
+        .withMessage(ErrorCode.PROFILE_IMAGE_ALREADY_DEFAULT.getMessage());
+
+    verify(s3Service, never()).removeProfileImage(anyString());
+  }
+
 }


### PR DESCRIPTION
## 🔍  요약
- Jacoco 설정
- 프로필 이미지 초기화 API 추가
- 회원정보 조회 API 응답 객체 수정

## #️⃣ 연관된 이슈
x

## 🛠️ 작업 내용
### Test Coverage Tool 추가
- 테스트 커버리지 툴인 `Jacoco`를 추가하였습니다.
- `/build/jacoco/html/index.html` 에서 테스트 커버리지 결과를 확인할 수 있습니다.
- 테스트가 필요없는 단순 `entity` `dto` 등은 커버리지에서 제외하도록 설정하였습니다.

### Test 중 Tailwind 관련 task 제외
- `build.gradle`에 테스트 task를 실행할 때, tailwind 관련 task는 실행되지 않도록 설정하였습니다.
- 제외된 Task
  - nodeSetup
  -  npmSetup
  - npmInstall
  - tailwindCss
  - processResources

### 프로필 이미지 초기화 API `/v1/users/me/profile-image/default` `PATCH`
- 프로필 이미지를 기본 이미지로 초기화 합니다.
- 이미 기본 이미지인 상태에서 요청시 상태코드 409를 응답합니다.

### 회원정보 조회 API 응답 데이터 수정
- 프로필 이미지가 기본 이미지인지 알려주는 boolean 타입 필드 `isDefaultProfileImage` 를 추가하였습니다.

## 💬 To Other
x
